### PR TITLE
Ajout enum role dans le model user + setup routes avec namespace pour…

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,15 @@ class User < ApplicationRecord
   has_many :galleries, dependent: :destroy
   has_many :registrations, dependent: :destroy
 
+  # Permet que chaque inscription soit uniquement en role members
+  enum role: { member: "member", admin: "admin" }
+
+  after_initialize :set_default_role, if: :new_record?
+
+  def set_default_role
+    self.role ||= "member"
+  end
+
   # Offre la possibilté à l'user d'ajouter un avatar
   has_one_attached :avatar
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,37 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+  namespace :admin do
+    resources :events do
+      resources :registrations, only: [:index, :show, :destroy]
+    end
+
+    resources :races do
+      resources :registrations, only: [:index, :show, :destroy]
+    end
+
+    resources :trainings do
+      resources :registrations, only: [:index, :show, :destroy]
+    end
+
+    resources :articles
+    resources :galleries
+  end
+end
+
+  namespace :members do
+    resources :events do
+        resources :registrations, only: [:create, :new, :destroy]
+      end
+
+   resources :races do
+        resources :registrations, only: [:create, :new, :destroy]
+      end
+
+    resources :trainings do
+        resources :registrations, only: [:create, :new, :destroy]
+      end
+
+    resources :articles, only: [:index, :show]
+    resources :galleries, only: [:index, :show]
 end


### PR DESCRIPTION
Ajout de la gestion des rôles utilisateurs avec enum dans le modèle User :
- Chaque nouvel utilisateur est automatiquement assigné au rôle member
- Ajout du callback after_initialize pour définir le rôle par défaut

Structure des routes repensée avec deux namespaces :
- admin : pour les interfaces et actions réservées aux administrateurs (gestion des events, trainings, races, articles, galeries et registrations)
- members : pour les membres, accès limité aux inscriptions et à la consultation des contenus.
