### PR TITLE
Correction du model gallery pour que l'admin puisse ajouter plusieurs…

### DIFF
--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -1,11 +1,14 @@
 class Gallery < ApplicationRecord
   belongs_to :user
 
-  # Offre à l'admin la possibilté d'ajouter des images pour la création d'une galerie
-  has_one_attached :image
+  # Offre à l'admin la possibilté d'ajouter plusieurs images pour la création d'une galerie
+  has_many_attached :images
+  # Permet de supprimer plusieurs images via le questionnaire view/galleries/_form.html.erb
+  attr_accessor :remove_images
+
   # Validation obligatoire pour pouvoir créer une gallerie
   validates :title, presence: { message: "Vous devez renseigner un titre" }, uniqueness:
   { message: "Ce titre est déjà utilisé" }
-  validates :image, presence: { message: "Vous devez ajouter une image" }
+  validates :images, presence: { message: "Vous devez ajouter une ou plusieurs image" }
   validates :date, presence: { message: "Vous devez renseigner une date" }
 end


### PR DESCRIPTION
👨‍💻CODE
- Modification du model Gallery pour pouvoir attacher plusieurs images  ou en supprimer

🧪TEST
- Affinage des tests rspec pour les validations notamment avec plusieurs images

<img width="777" height="300" alt="Capture d’écran 2025-07-22 à 17 28 43" src="https://github.com/user-attachments/assets/7bea018c-d09c-4008-8a9a-76a5365caa40" />
<img width="472" height="202" alt="Capture d’écran 2025-07-22 à 17 23 01" src="https://github.com/user-attachments/assets/6fcfc695-cdf6-4265-abb0-c8e5bf316e58" />
 
