### PR TITLE
Tdd admin registrations controller

### DIFF
--- a/spec/requests/admin/registrations_spec.rb
+++ b/spec/requests/admin/registrations_spec.rb
@@ -138,4 +138,18 @@ RSpec.describe "Admin::Registrations", type: :request do
       end
     end
   end
+
+  describe "DELETE/admin/events/:events_id/registrations" do # Méthode destroy event
+    context "Quand l'admin delete une inscription lié à événement de type course" do
+      it "supprime l'inscription, redirige l'user (302), et valide le test" do
+        # Vérifie que les informations du participant inscrit à l'événement sont bien affichées à l'admin
+        registration = Registration.create!(user: user, registerable: event)
+        # expect {...} permet de tester un changement d'état, test les créations et suppressions
+        expect {
+          delete admin_event_registration_path(event, registration)
+        }.to change(Registration, :count).by(-1) # Ici permet de vérifier que l'inscription est bien supprimé en DB
+        expect(response).to have_http_status(:redirect) # Redirige l'user après suppression (302)
+      end
+    end
+  end
 end

--- a/spec/requests/admin/registrations_spec.rb
+++ b/spec/requests/admin/registrations_spec.rb
@@ -14,6 +14,21 @@ RSpec.describe "Admin::Registrations", type: :request do
     )
   end
 
+  let(:user) do
+    User.create!(
+      user_name: "testusername",
+      role: "member",
+      first_name: "testfirst",
+      last_name: "testlast",
+      email: "test@mail.com",
+      phone_number: "0678456123",
+      address: "testaddress",
+      post_code: "73000",
+      town: "testville",
+      country: "testcountry"
+    )
+  end
+
   let(:race) do
     Race.create!(
       name: "testname",
@@ -55,14 +70,71 @@ RSpec.describe "Admin::Registrations", type: :request do
     training
   end
 
-  describe 
-
-  describe "GET/admin/events/:events_id/registrations" do # Méthode Index
-    context "Quand un admin accéde à une inscription d'un événement" do
+  describe "GET/admin/events/:events_id/registrations" do # Méthode Index event
+    context "Quand un admin accéde à une inscription d'une activité de type event" do
       it " retourne un status 200, affiche les inscriptions et valide le test" do
         get admin_event_registrations_path(event, format: :html)
         expect(response).to have_http_status(:ok)
         expect(response.body).to include(event.name)
+      end
+    end
+  end
+
+  describe "GET/admin/races/:races_id/registrations" do # Méthode Index race
+    context "Quand un admin accéde à une inscription d'une activité de type race" do
+      it " retourne un status 200, affiche les inscriptions et valide le test" do
+        get admin_race_registrations_path(race, format: :html)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(race.name)
+      end
+    end
+  end
+
+  describe "GET/admin/trainings/:trainings_id/registrations" do # Méthode Index training
+    context "Quand un admin accéde à une inscription d'une activité de type training" do
+      it " retourne un status 200, affiche les inscriptions et valide le test" do
+        get admin_training_registrations_path(training, format: :html)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(training.name)
+      end
+    end
+  end
+
+  describe "GET/admin/events/:events_id/registrations" do # Méthode show event
+    context "Quand un admin est connecté et affiche les détails des inscriptions à un événement de type event" do
+      it "retourne un status 200, affiche les informations des users inscrit" do
+        # Vérifie que les informations du participant inscrit à l'événement sont bien affichées à l'admin
+        Registration.create!(user: user, registerable: event)
+        get admin_event_registrations_path(event)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(user.last_name)
+        expect(response.body).to include(user.first_name)
+      end
+    end
+  end
+
+  describe "GET/admin/races/:races_id/registrations" do # Méthode show race
+    context "Quand un admin est connecté et affiche les détails des inscriptions à un événement de type race" do
+      it "retourne un status 200, affiche les informations des users inscrit" do
+        # Vérifie que les informations du participant inscrit à l'événement sont bien affichées à l'admin
+        Registration.create!(user: user, registerable: race)
+        get admin_race_registrations_path(race)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(user.last_name)
+        expect(response.body).to include(user.first_name)
+      end
+    end
+  end
+
+  describe "GET/admin/trainings/:trainings_id/registrations" do # Méthode show training
+    context "Quand un admin est connecté et affiche les détails des inscriptions à un événement de type training" do
+      it "retourne un status 200, affiche les informations des users inscrit" do
+        # Vérifie que les informations du participant inscrit à l'événement sont bien affichées à l'admin
+        Registration.create!(user: user, registerable: training)
+        get admin_training_registrations_path(training)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(user.last_name)
+        expect(response.body).to include(user.first_name)
       end
     end
   end

--- a/spec/requests/admin/registrations_spec.rb
+++ b/spec/requests/admin/registrations_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe "Admin::Registrations", type: :request do
     training
   end
 
-  describe "GET/admin/events/:events_id/registrations" do # Méthode Index event
-    context "Quand un admin accéde à une inscription d'une activité de type event" do
+  describe "GET /admin/events/:event_id/registrations" do # Méthode Index event
+    context "Quand un admin accéde aux inscriptions d'une activité de type event" do
       it " retourne un status 200, affiche les inscriptions et valide le test" do
         get admin_event_registrations_path(event, format: :html)
         expect(response).to have_http_status(:ok)
@@ -80,8 +80,8 @@ RSpec.describe "Admin::Registrations", type: :request do
     end
   end
 
-  describe "GET/admin/races/:races_id/registrations" do # Méthode Index race
-    context "Quand un admin accéde à une inscription d'une activité de type race" do
+  describe "GET /admin/races/:race_id/registrations" do # Méthode Index race
+    context "Quand un admin accéde aux inscriptions d'une activité de type race" do
       it " retourne un status 200, affiche les inscriptions et valide le test" do
         get admin_race_registrations_path(race, format: :html)
         expect(response).to have_http_status(:ok)
@@ -90,8 +90,8 @@ RSpec.describe "Admin::Registrations", type: :request do
     end
   end
 
-  describe "GET/admin/trainings/:trainings_id/registrations" do # Méthode Index training
-    context "Quand un admin accéde à une inscription d'une activité de type training" do
+  describe "GET /admin/trainings/:training_id/registrations" do # Méthode Index training
+    context "Quand un admin accéde aux inscriptions d'une activité de type training" do
       it " retourne un status 200, affiche les inscriptions et valide le test" do
         get admin_training_registrations_path(training, format: :html)
         expect(response).to have_http_status(:ok)
@@ -100,12 +100,12 @@ RSpec.describe "Admin::Registrations", type: :request do
     end
   end
 
-  describe "GET/admin/events/:events_id/registrations" do # Méthode show event
+  describe "GET /admin/events/:event_id/registrations/:id" do # Méthode show event
     context "Quand un admin est connecté et affiche les détails des inscriptions à un événement de type event" do
       it "retourne un status 200, affiche les informations des users inscrit" do
-        # Vérifie que les informations du participant inscrit à l'événement sont bien affichées à l'admin
-        Registration.create!(user: user, registerable: event)
-        get admin_event_registrations_path(event)
+        # Crée une inscription qui sera visible pour l'admin
+        registration = Registration.create!(user: user, registerable: event)
+        get admin_event_registration_path(event, registration)
         expect(response).to have_http_status(:ok)
         expect(response.body).to include(user.last_name)
         expect(response.body).to include(user.first_name)
@@ -113,12 +113,12 @@ RSpec.describe "Admin::Registrations", type: :request do
     end
   end
 
-  describe "GET/admin/races/:races_id/registrations" do # Méthode show race
+  describe "GET /admin/races/:race_id/registrations/:id" do # Méthode show race
     context "Quand un admin est connecté et affiche les détails des inscriptions à un événement de type race" do
       it "retourne un status 200, affiche les informations des users inscrit" do
-        # Vérifie que les informations du participant inscrit à l'événement sont bien affichées à l'admin
-        Registration.create!(user: user, registerable: race)
-        get admin_race_registrations_path(race)
+        # Crée une inscription qui sera visible pour l'admin
+        registration = Registration.create!(user: user, registerable: race)
+        get admin_race_registration_path(race, registration)
         expect(response).to have_http_status(:ok)
         expect(response.body).to include(user.last_name)
         expect(response.body).to include(user.first_name)
@@ -126,12 +126,12 @@ RSpec.describe "Admin::Registrations", type: :request do
     end
   end
 
-  describe "GET/admin/trainings/:trainings_id/registrations" do # Méthode show training
+  describe "GET /admin/trainings/:training_id/registrations/:id" do # Méthode show training
     context "Quand un admin est connecté et affiche les détails des inscriptions à un événement de type training" do
       it "retourne un status 200, affiche les informations des users inscrit" do
-        # Vérifie que les informations du participant inscrit à l'événement sont bien affichées à l'admin
-        Registration.create!(user: user, registerable: training)
-        get admin_training_registrations_path(training)
+        # Crée une inscription qui sera visible pour l'admin
+        registration = Registration.create!(user: user, registerable: training)
+        get admin_training_registration_path(training, registration)
         expect(response).to have_http_status(:ok)
         expect(response.body).to include(user.last_name)
         expect(response.body).to include(user.first_name)
@@ -139,14 +139,42 @@ RSpec.describe "Admin::Registrations", type: :request do
     end
   end
 
-  describe "DELETE/admin/events/:events_id/registrations" do # Méthode destroy event
-    context "Quand l'admin delete une inscription lié à événement de type course" do
+  describe "DELETE /admin/events/:event_id/registrations/:id" do # Méthode destroy event
+    context "Quand l'admin delete une inscription lié à événement de type event" do
       it "supprime l'inscription, redirige l'user (302), et valide le test" do
-        # Vérifie que les informations du participant inscrit à l'événement sont bien affichées à l'admin
+        # Crée une inscription qui sera supprimée pour le test
         registration = Registration.create!(user: user, registerable: event)
         # expect {...} permet de tester un changement d'état, test les créations et suppressions
         expect {
           delete admin_event_registration_path(event, registration)
+        }.to change(Registration, :count).by(-1) # Ici permet de vérifier que l'inscription est bien supprimé en DB
+        expect(response).to have_http_status(:redirect) # Redirige l'user après suppression (302)
+      end
+    end
+  end
+
+  describe "DELETE /admin/races/:race_id/registrations/:id" do # Méthode destroy race
+    context "Quand l'admin delete une inscription lié à événement de type race" do
+      it "supprime l'inscription, redirige l'user (302), et valide le test" do
+        # Crée une inscription qui sera supprimée pour le test
+        registration = Registration.create!(user: user, registerable: race)
+        # expect {...} permet de tester un changement d'état, test les créations et suppressions
+        expect {
+          delete admin_race_registration_path(race, registration)
+        }.to change(Registration, :count).by(-1) # Ici permet de vérifier que l'inscription est bien supprimé en DB
+        expect(response).to have_http_status(:redirect) # Redirige l'user après suppression (302)
+      end
+    end
+  end
+
+  describe "DELETE /admin/trainings/:training_id/registrations/:id" do # Méthode destroy training
+    context "Quand l'admin delete une inscription lié à événement de type training" do
+      it "supprime l'inscription, redirige l'user (302), et valide le test" do
+        # Crée une inscription qui sera supprimée pour le test
+        registration = Registration.create!(user: user, registerable: training)
+        # expect {...} permet de tester un changement d'état, test les créations et suppressions
+        expect {
+          delete admin_training_registration_path(training, registration)
         }.to change(Registration, :count).by(-1) # Ici permet de vérifier que l'inscription est bien supprimé en DB
         expect(response).to have_http_status(:redirect) # Redirige l'user après suppression (302)
       end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Admin::Users", type: :request do
       town: "testville",
       country: "testcountry",
       password: "Exemples1,",
-      password_confirmation: "Exemples1,",
+      password_confirmation: "Exemples1,"
     )
   end
 


### PR DESCRIPTION
🧪TEST
- Écriture des tests de type request pour le controller Admin::Registrations 
- Tests des actions Index, Show et Destroy pour les modèles Events, Trainings et Races, liés par une relation polymorphe

<img width="779" height="735" alt="Capture d’écran 2025-07-24 à 14 22 44" src="https://github.com/user-attachments/assets/5ce36dd3-383f-4863-b961-8d1f2a774579" />
<img width="906" height="805" alt="Capture d’écran 2025-07-24 à 14 23 01" src="https://github.com/user-attachments/assets/2f4fa366-13ec-4001-99e2-b162cd4a1ff8" />
<img width="883" height="780" alt="Capture d’écran 2025-07-24 à 14 24 09" src="https://github.com/user-attachments/assets/7557d4b4-519d-43a3-9007-85c31578d44c" />


