### PR TITLE
Feature secure club member signup

### DIFF
--- a/app/javascript/controllers/club_member_check_controller.js
+++ b/app/javascript/controllers/club_member_check_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="club-member-check"
+export default class extends Controller {
+  static targets = ["select", "clubNameWrapper", "affiliationWrapper"];
+
+  connect() {
+    this.toggle();
+  }
+
+  toggle() {
+    if (this.selectTarget.value === "true") {
+      // S'il est membre de Navès
+      this.clubNameWrapperTarget.style.display = "none";
+      this.affiliationWrapperTarget.style.display = "block";
+    } else {
+      // S'il n'est PAS membre de Navès
+      this.clubNameWrapperTarget.style.display = "block";
+      this.affiliationWrapperTarget.style.display = "none";
+    }
+  }
+}

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -49,12 +49,12 @@
                   }
                 } %>
 
-    <!-- Champ caché si membre du club -->
+    <%# Champ caché si membre du club %>
     <div data-club-member-check-target="affiliationWrapper" style="<%= f.object.club_member? ? '' : 'display: none;' %>">
       <%= f.hidden_field :club_affiliation_number, value: User::VALID_NUMBER_CLUB_AFFILIATION %>
     </div>
 
-    <!-- Champ nom du club visible uniquement si PAS membre -->
+    <%# Champ nom du club visible uniquement si PAS membre %>
     <div data-club-member-check-target="clubNameWrapper" style="<%= f.object.club_member? ? 'display: none;' : '' %>">
       <%= f.input :club_name, label: "Nom du club" %>
     </div>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,52 +1,69 @@
 <%= simple_form_for [:admin, @user], html: { multipart: true } do |f| %>
-
   <fieldset>
     <legend>Informations personnelles</legend>
-  <%= f.input :user_name, label: "Pseudo" %>
-  <%= f.input :avatar, as: :file, label: "Avatar" %>
-  <% if f.object.persisted? && f.object.avatar.attached? %>
-    <div class="mt-2">
-      <p>Avatar actuel :</p>
-      <%= image_tag(f.object.avatar, size: "150x100", class: "img-thumbnail") %><br>
-      <%= f.check_box :remove_avatar %>
-      <%= f.label :remove_avatar, "Supprimer l'image actuelle" %>
-    </div>
-  <% end %>
-  <%= f.input :role, collection: User.roles.keys, label: "Rôle", prompt: "Sélectionner un rôle" %>
-  <%= f.input :email, label: "Adresse email" %>
-  <%= f.input :first_name, label: "Prénom" %>
-  <%= f.input :last_name, label: "Nom de famille" %>
-  <%= f.input :birth_date, label: "Date de naissance" do %>
-    <%= f.date_field :birth_date, class: "form-control" %>
-  <% end %>
-  <%= f.input :phone_number, label: "Numéro de téléphone" %>
-  <%= f.input :address, label: "Adresse" %>
-  <%= f.input :post_code, label: "Code postal" %>
-  <%= f.input :town, label: "Ville" %>
-  <%= f.input :country, label: "Pays", as: :country, priority: ["France"], prompt: "Sélectionner un pays" %>
+    <%= f.input :user_name, label: "Pseudo" %>
+    <%= f.input :avatar, as: :file, label: "Avatar" %>
+    <% if f.object.persisted? && f.object.avatar.attached? %>
+      <div class="mt-2">
+        <p>Avatar actuel :</p>
+        <%= image_tag(f.object.avatar, size: "150x100", class: "img-thumbnail") %><br>
+        <%= f.check_box :remove_avatar %>
+        <%= f.label :remove_avatar, "Supprimer l'image actuelle" %>
+      </div>
+    <% end %>
+    <%= f.input :role, collection: User.roles.keys, label: "Rôle", prompt: "Sélectionner un rôle" %>
+    <%= f.input :email, label: "Adresse email" %>
+    <%= f.input :first_name, label: "Prénom" %>
+    <%= f.input :last_name, label: "Nom de famille" %>
+    <%= f.input :birth_date, label: "Date de naissance" do %>
+      <%= f.date_field :birth_date, class: "form-control" %>
+    <% end %>
+    <%= f.input :phone_number, label: "Numéro de téléphone" %>
+    <%= f.input :address, label: "Adresse" %>
+    <%= f.input :post_code, label: "Code postal" %>
+    <%= f.input :town, label: "Ville" %>
+    <%= f.input :country, label: "Pays", as: :country, priority: ["France"], prompt: "Sélectionner un pays" %>
   </fieldset>
 
   <fieldset>
     <legend>Informations sur la licence</legend>
-  <%= f.input :license_code,
-  as: :select,
-  collection: User::LICENCE_CODES,
-  label: "Code de licence" %>
-  <%= f.input :license_number, label: "Numéro de licence" %>
+    <%= f.input :license_code,
+                as: :select,
+                collection: User::LICENCE_CODES,
+                label: "Code de licence" %>
+    <%= f.input :license_number, label: "Numéro de licence" %>
   </fieldset>
 
-  <fieldset>
+  <fieldset data-controller="club-member-check">
     <legend>Informations sur le club</legend>
-  <%= f.input :club_member,
-            label: "Membre du club ?",
-            as: :select,
-            collection: [["Oui", true], ["Non", false]],
-            include_blank: false,
-            input_html: { value_as_boolean: true } %>
+    <%= f.input :club_member,
+                label: "Membre du club ?",
+                as: :select,
+                collection: [["Oui", true], ["Non", false]],
+                include_blank: false,
+                input_html: {
+                  value_as_boolean: true,
+                  data: {
+                    "club-member-check-target": "select",
+                    action: "change->club-member-check#toggle"
+                  }
+                } %>
 
-  <%= f.input :club_name, label: "Nom du club" %>
+    <div data-club-member-check-target="affiliationWrapper" style="<%= f.object.club_member? ? '' : 'display: none;' %>">
+      <%= f.input :club_affiliation_number,
+                  label: "Numéro d'affiliation du club" %>
+    </div>
+
+    <div data-club-member-check-target="clubNameWrapper" style="<%= f.object.club_member? ? 'display: none;' : '' %>">
+      <% if f.object.club_member? %>
+        <%= f.input :club_name,
+                    label: "Nom du club",
+                    input_html: { readonly: true } %>
+      <% else %>
+        <%= f.input :club_name, label: "Nom du club" %>
+      <% end %>
+    </div>
   </fieldset>
-
 
   <%= f.button :submit, "Valider", class: "btn btn-primary" %>
 <% end %>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -37,7 +37,7 @@
   <fieldset data-controller="club-member-check">
     <legend>Informations sur le club</legend>
     <%= f.input :club_member,
-                label: "Membre du club ?",
+                label: "Licencié du club ?",
                 as: :select,
                 collection: [["Oui", true], ["Non", false]],
                 include_blank: false,
@@ -49,19 +49,14 @@
                   }
                 } %>
 
+    <!-- Champ caché si membre du club -->
     <div data-club-member-check-target="affiliationWrapper" style="<%= f.object.club_member? ? '' : 'display: none;' %>">
-      <%= f.input :club_affiliation_number,
-                  label: "Numéro d'affiliation du club" %>
+      <%= f.hidden_field :club_affiliation_number, value: User::VALID_NUMBER_CLUB_AFFILIATION %>
     </div>
 
+    <!-- Champ nom du club visible uniquement si PAS membre -->
     <div data-club-member-check-target="clubNameWrapper" style="<%= f.object.club_member? ? 'display: none;' : '' %>">
-      <% if f.object.club_member? %>
-        <%= f.input :club_name,
-                    label: "Nom du club",
-                    input_html: { readonly: true } %>
-      <% else %>
-        <%= f.input :club_name, label: "Nom du club" %>
-      <% end %>
+      <%= f.input :club_name, label: "Nom du club" %>
     </div>
   </fieldset>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -12,18 +12,49 @@
     end_year: Date.current.year - 10, # Permet l'inscription à partir de 10 ans
     order: [:day, :month, :year] %>
 
-    <%= f.input :address %>
-    <%= f.input :post_code %>
-    <%= f.input :town %>
-    <%= f.input :country %>
+    <%= f.input :phone_number,
+                hint: "Nous permet de vous contacter rapidement en cas d'informations importantes (annulation, urgence…)" %>
 
-    <%= f.input :club_name, required: true %>
-    <%= f.input :club_member, as: :select, collection: [['Oui', true], ['Non', false]], required: true %>
+    <%= f.input :address, required: true %>
+    <%= f.input :post_code, required: true %>
+    <%= f.input :town, required: true %>
+    <%= f.input :country, as: :country, priority: ["France"], required: true %>
 
-    <%= f.input :phone_number, required: true %>
-    <%= f.input :license_code, required: true %>
+  <div data-controller="club-member-check">
+    <%= f.input :club_member,
+                label: "Êtes-vous membre du club de Navès ?",
+                as: :select,
+                collection: [['Oui', true], ['Non', false]],
+                include_blank: "Sélectionner",
+                required: true,
+                input_html: {
+                  data: {
+                    "club-member-check-target": "select",
+                    action: "change->club-member-check#toggle"
+                  }
+                } %>
+
+    <%# Champ NOM DU CLUB affiché uniquement si club_member = false %>
+    <div data-club-member-check-target="clubNameWrapper" style="display: none;">
+      <%= f.input :club_name, label: "Nom de votre club" %>
+    </div>
+
+    <%# Champ NUMERO D'AFFILIATION affiché uniquement si club_member = true %>
+    <div data-club-member-check-target="affiliationWrapper" style="display: none;">
+      <%= f.input :club_affiliation_number, label: "Numéro d'affiliation du club de Navès" %>
+    </div>
+  </div>
+
+
+
+    <%= f.input :license_code,
+                required: true,
+                as: :select,
+                collection: User::LICENCE_CODES,
+                include_blank: "Sélectionner un code" %>
+
     <%= f.input :license_number, required: true %>
-    
+
     <%= f.input :avatar, as: :file, required: false %>
 
 
@@ -32,7 +63,7 @@
                 input_html: { autocomplete: "email" }%>
     <%= f.input :password,
                 required: true,
-                hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
+                hint: "Doit contenir au moins 8 caractères, dont une majuscule, une minuscule, un chiffre et un caractère spécial.",
                 input_html: { autocomplete: "new-password" } %>
     <%= f.input :password_confirmation,
                 required: true,

--- a/db/migrate/20250731081019_add_club_affiliation_number_to_users.rb
+++ b/db/migrate/20250731081019_add_club_affiliation_number_to_users.rb
@@ -1,0 +1,5 @@
+class AddClubAffiliationNumberToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :club_affiliation_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_30_211137) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_31_081019) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -132,6 +132,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_30_211137) do
     t.string "license_number"
     t.boolean "club_member"
     t.string "club_name"
+    t.string "club_affiliation_number"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["license_number"], name: "index_users_on_license_number", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
🗂️ Model User :
- Ajout du champ club_affiliation_number (numéro d’affiliation officiel du club de Navès).
- Ajout de la constante VALID_NUMBER_CLUB_AFFILIATION pour forcer le numéro C0637.
- Callback set_club_name_if_member pour forcer automatiquement club_name = "Navès" si l’utilisateur est membre du club.
- Mise à jour des validations 

🎨 FRONT (membres) :
- Ajout du champ "Êtes-vous membre du club de Navès ?" avec sélection Oui / Non.
- Affichage conditionnel des champs 
. Si Oui → affichage du champ club_affiliation_number uniquement.
. Si Non → affichage du champ club_name uniquement.
- Utilisation de Stimulus (club-member-check) pour gérer l’affichage dynamique.
- Nettoyage des champs non nécessaires (ex : cylindrée, numéro de course…).

🎨 Front (user) :
- Même logique d’affichage conditionnel avec Stimulus.
- Affichage en lecture/écriture du club_name et club_affiliation_number selon le statut club_membre.

<img width="930" height="630" alt="Capture d’écran 2025-07-31 à 13 40 42" src="https://github.com/user-attachments/assets/ed80287c-e3ff-41ab-bd55-9f2c3182d282" />
<img width="666" height="469" alt="Capture d’écran 2025-07-31 à 13 41 03" src="https://github.com/user-attachments/assets/7b0f21d3-2406-4737-9301-da6f1b93b3f4" />






