### PR TITLE
✨Ajout de la gestion du statut des inscriptions dans la vue admin/registrations#show

### DIFF
--- a/app/controllers/admin/registration_validations_controller.rb
+++ b/app/controllers/admin/registration_validations_controller.rb
@@ -6,7 +6,7 @@ module Admin
       # Change le statut de l'inscription en "validated" (grâce à l'enum dans le modèle qui est par default "pending")
       @registration.validated!
       # Redirige l'admin vers la page précédente (ex: la course), ou vers le dashboard si la redirection échoue
-      # Affiche un message flash de confirmation
+      # Affiche un message de confirmation
       redirect_back fallback_location: admin_dashboard_path, notice: "Inscription validée avec succès."
     end
 
@@ -14,6 +14,12 @@ module Admin
       @registration.rejected!
       redirect_back fallback_location: admin_dashboard_path, alert: "Inscription refusée"
     end
+
+    def reset
+      @registration.update(status: "pending")
+      redirect_back fallback_location: admin_dashboard_path, notice: "Inscription remise en attente"
+    end
+
 
     private
 

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -7,10 +7,19 @@ module RegistrationHelper
     return unless current_user&.member? || current_user&.admin?
 
     # Permet de vérifier si l'utilisateur est déjà inscrit à cette ressource
-    already_registered = current_user.registrations.exists?(registerable: resource)
+    registration = current_user.registrations.find_by(registerable: resource)
 
-    if already_registered
-      content_tag(:span, "Vous êtes déja inscrit", class: "btn btn-secondary disabled")
+    if registration.present?
+      case registration.status
+      when "pending"
+        content_tag(:span, "Inscription enregistrée en attente de validation", class: "btn btn-warning disabled")
+      when "validated"
+        content_tag(:span, "Inscription enregistrée & validée", class: "btn btn-success disabled")
+      when "rejected"
+        content_tag(:span, "Inscription refusée", class: "btn btn-danger disabled")
+      else
+        content_tag(:span, "Inscription enregistrée", class: "btn btn-secondary disabled")
+      end
     else
       path = case resource
              when Race

--- a/app/views/admin/races/show.html.erb
+++ b/app/views/admin/races/show.html.erb
@@ -21,6 +21,7 @@
           <span><%= registration.user.first_name %> <%= registration.user.last_name %></span>
         </div>
       <% end %>
+        <%= registration.status %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/admin/registrations/index.html.erb
+++ b/app/views/admin/registrations/index.html.erb
@@ -3,5 +3,6 @@
 <% @registrations.each do |registration| %>
   <p><%= registration.registerable.name %></p>
   <p><%= registration.user.first_name %> <%= registration.user.last_name %></p>
-  
+  <p><%= registration.status %></p>
+
 <% end %>

--- a/app/views/admin/registrations/show.html.erb
+++ b/app/views/admin/registrations/show.html.erb
@@ -34,3 +34,26 @@
     <li><strong>Type de moteur :</strong> <%= @registration.stroke_type %></li>
   </ul>
 </fieldset>
+
+<% if @registration.pending? && current_user.admin? %>
+  <div>
+    <p>Statut actuel : <%= @registration.status.capitalize %></p>
+
+    <div class= "btn-group">
+      <%= link_to "Valider l'inscription",  admin_validate_admin_registration_path(@registration),
+        method: :patch,
+        class: "btn btn-success",
+        data: { turbo_confirm: "Valider cette inscription ?" } %>
+
+      <%= link_to "Refuser l'inscription", admin_reject_admin_registration_path(@registration),
+        method: :patch,
+        class: "btn btn-danger",
+        data: { turbo_confirm: "Refuser cette inscription ?" }  %>
+    </div>
+  </div>
+
+  <% elsif @registration.validated? %>
+    <p class= "text-success"> Statut : Inscription validée</p>
+  <% elsif @registration.rejected? %>
+    <p class= "text-danger"> Statut : Inscription rejetée</p>
+<% end %>

--- a/app/views/admin/registrations/show.html.erb
+++ b/app/views/admin/registrations/show.html.erb
@@ -39,17 +39,14 @@
   <div>
     <p>Statut actuel : <%= @registration.status.capitalize %></p>
 
-    <div class= "btn-group">
-      <%= link_to "Valider l'inscription",  admin_validate_admin_registration_path(@registration),
-        method: :patch,
-        class: "btn btn-success",
-        data: { turbo_confirm: "Valider cette inscription ?" } %>
+    <%= simple_form_for @registration, url: admin_validate_admin_registration_path(@registration), method: :patch, html: { class: "d-inline" } do |f| %>
+      <%= f.button :submit, "Valider l'inscription", class: "btn btn-success", data: { turbo_confirm: "Valider cette inscription ?" } %>
+    <% end %>
 
-      <%= link_to "Refuser l'inscription", admin_reject_admin_registration_path(@registration),
-        method: :patch,
-        class: "btn btn-danger",
-        data: { turbo_confirm: "Refuser cette inscription ?" }  %>
-    </div>
+    <%= simple_form_for @registration, url: admin_reject_admin_registration_path(@registration), method: :patch, html: { class: "d-inline" } do |f| %>
+      <%= f.button :submit, "Refuser l'inscription", class: "btn btn-danger", data: { turbo_confirm: "Refuser cette inscription ?" } %>
+    <% end %>
+
   </div>
 
   <% elsif @registration.validated? %>

--- a/app/views/admin/registrations/show.html.erb
+++ b/app/views/admin/registrations/show.html.erb
@@ -35,22 +35,29 @@
   </ul>
 </fieldset>
 
-<% if @registration.pending? && current_user.admin? %>
-  <div>
-    <p>Statut actuel : <%= @registration.status.capitalize %></p>
+<% return unless current_user.admin? %> <%# Vérifie que seul un admin peut voir ces actions %>
+  <p><strong>Statut actuel :</strong> <%= @registration.status.capitalize %></p>
 
-    <%= simple_form_for @registration, url: admin_validate_admin_registration_path(@registration), method: :patch, html: { class: "d-inline" } do |f| %>
-      <%= f.button :submit, "Valider l'inscription", class: "btn btn-success", data: { turbo_confirm: "Valider cette inscription ?" } %>
+  <div class="btn-group mt-2">
+
+    <% unless @registration.validated? %> <!-- Exécute le code sauf si l'inscription est validée -->
+      <%= form_with url: admin_validate_admin_registration_path(@registration), method: :patch, class: "d-inline" do %>
+        <%= submit_tag "Valider", class: "btn btn-success btn-sm", data: { turbo_confirm: "Confirmer la validation ?" } %>
+      <% end %>
     <% end %>
 
-    <%= simple_form_for @registration, url: admin_reject_admin_registration_path(@registration), method: :patch, html: { class: "d-inline" } do |f| %>
-      <%= f.button :submit, "Refuser l'inscription", class: "btn btn-danger", data: { turbo_confirm: "Refuser cette inscription ?" } %>
+    <% unless @registration.rejected? %> <%# Exécute le code sauf si l'inscription est rejetée %>
+      <%= form_with url: admin_reject_admin_registration_path(@registration), method: :patch, class: "d-inline" do %>
+        <%= submit_tag "Refuser", class: "btn btn-danger btn-sm", data: { turbo_confirm: "Confirmer le refus ?" } %>
+      <% end %>
+    <% end %>
+
+    <% unless @registration.pending? %>  <%# Exécute le code sauf si l'inscription est en attente %>
+      <%= form_with url: admin_reset_admin_registration_path(@registration), method: :patch, class: "d-inline" do %>
+        <%#  Crée un formulaire PATCH vers la route de réinitialisation (retour à 'pending') %>
+        <%= submit_tag "Remettre en attente", class: "btn btn-warning btn-sm", data: { turbo_confirm: "Remettre l'inscription en attente ?" } %>
+      <% end %>
     <% end %>
 
   </div>
 
-  <% elsif @registration.validated? %>
-    <p class= "text-success"> Statut : Inscription validée</p>
-  <% elsif @registration.rejected? %>
-    <p class= "text-danger"> Statut : Inscription rejetée</p>
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
     # to: "registration_validations#validate", as: :validate_admin_registration
     patch "registrations/:id/validate", to: "registration_validations#validate", as: :validate_admin_registration
     patch "registrations/:id/reject",   to: "registration_validations#reject",   as: :reject_admin_registration
+    patch "registrations/:id/reset", to: "registration_validations#reset", as: :reset_admin_registration
     get "dashboard", to: "dashboard#index"
   end
 


### PR DESCRIPTION
- Ajout de l'affichage du statut de l'inscription dans la vue `admin/registrations#show`
- Mise en place des boutons d'action (Valider / Refuser / Remettre en attente) pour permettre à l'admin de gérer manuellement les statuts d'inscription
- Intégration des routes PATCH custom (validate, reject, reset) avec `form_with` pour assurer une bonne compatibilité Turbo
- Utilisation d'une guard clause pour s'assurer que seul un admin peut voir ces actions
