### PR TITLE
✨ Ajout de la possibilité de supprimer l’image d’une course depuis le formulaire (coté Admin)

### DIFF
--- a/app/controllers/admin/races_controller.rb
+++ b/app/controllers/admin/races_controller.rb
@@ -48,7 +48,7 @@ module Admin
     end
 
     def race_params
-      params.require(:race).permit(:name, :description, :date, :hour, :image)
+      params.require(:race).permit(:name, :description, :date, :hour, :image, :remove_image)
     end
   end
 end

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -5,8 +5,20 @@ class Race < ApplicationRecord
 
   # Offre à l'admin la possibilté d'ajouter une image pour la création d'une course
   has_one_attached :image
+  # Permet de supprimer l'image via la partiale view/race/_form.html.erb
+  attr_accessor :remove_image
   # Validation obligatoire pour pouvoir créer une course
   validates :name, presence: { message: "Vous devez renseigner un nom" }
   validates :date, presence: { message: "Vous devez renseigner une date" }
   validates :hour, presence: { message: "Vous devez renseigner une heure" }
+
+  # Purge l'image si la checkbox est cochée
+  before_save :purge_image, if: -> { remove_image == "1" }
+
+  private
+
+  # Permet de supprimer l'image
+  def purge_image
+    image.purge_later
+  end
 end

--- a/app/views/admin/races/_form.html.erb
+++ b/app/views/admin/races/_form.html.erb
@@ -5,6 +5,19 @@
     <%= f.date_field :date, class: "form-control" %>
   <% end %>
   <%= f.input :hour, as: :time, label: "Heure de la course" %>
+
+   <div class="col-12">
+          <%# Affiche l’avatar actuel uniquement si le blob est bien persisté %>
   <%= f.input :image, as: :file, label: "Image de la course" %>
+          <% if @image.attached? && @image.blob&.persisted? %>
+            <div class="mb-2">
+              <p class="mb-1">Image actuelle :</p>
+              <%= image_tag url_for(resource.image), size: "150x100", class: "img-thumbnail mb-2" %><br>
+              <div class="form-check">
+                <%= f.check_box :remove_image, class: "form-check-input" %>
+                <%= f.label :remove_image, "Supprimer l'image actuel", class: "form-check-label" %>
+              </div>
+            </div>
+          <% end %>
   <%= f.button :submit, "Valider", class: "btn btn-primary" %>
 <% end %>

--- a/app/views/admin/races/_form.html.erb
+++ b/app/views/admin/races/_form.html.erb
@@ -7,12 +7,12 @@
   <%= f.input :hour, as: :time, label: "Heure de la course" %>
 
    <div class="col-12">
-          <%# Affiche l’avatar actuel uniquement si le blob est bien persisté %>
+          <%# Affiche l’image actuelle uniquement si elle est bien persistée %>
   <%= f.input :image, as: :file, label: "Image de la course" %>
-          <% if @image.attached? && @image.blob&.persisted? %>
+          <% if f.object.image.attached? && f.object.image.attachment&.persisted? %>
             <div class="mb-2">
               <p class="mb-1">Image actuelle :</p>
-              <%= image_tag url_for(resource.image), size: "150x100", class: "img-thumbnail mb-2" %><br>
+              <%= image_tag f.object.image, size: "150x100", class: "img-thumbnail mb-2" %><br>
               <div class="form-check">
                 <%= f.check_box :remove_image, class: "form-check-input" %>
                 <%= f.label :remove_image, "Supprimer l'image actuel", class: "form-check-label" %>
@@ -21,3 +21,4 @@
           <% end %>
   <%= f.button :submit, "Valider", class: "btn btn-primary" %>
 <% end %>
+</div>


### PR DESCRIPTION


🗃️ MODEL
- L’admin peut désormais gérer l’image d’une course 
- Ajout d’une checkbox “Supprimer l’image actuelle” dans le formulaire de création/édition.
- Implémentation d’un attr_accessor :remove_image dans le modèle Race.
- Modification de la partial _form.html.erb pour afficher l’image actuelle + la case de suppression.
- Ajout de la logique dans Race avec un before_save :purge_image.
- L’admin peut téléverser une image lors de la création d'une course.
- L’admin peut supprimer l’image existante en cochant la checkbox à cet effet.

<img width="638" height="323" alt="image" src="https://github.com/user-attachments/assets/952d3ab0-8473-40dd-82ab-cdeb0e4fd86e" />
<img width="566" height="301" alt="image" src="https://github.com/user-attachments/assets/8d008912-1a16-4f7b-b8c5-2442f2b0cc7f" />
<img width="695" height="338" alt="image" src="https://github.com/user-attachments/assets/e583d55e-a177-406f-9689-23abbf2e5eab" />
