### PR TITLE
✨ Amélioration du style du dashboard admin

### DIFF
--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -7,113 +7,9 @@
   </div>
 </section>
 
-<section class="container my-5">
-  <% has_events = @events.present? %>
-
-
-  <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-4">
-    <h2 class="section-title mb-0">
-      <i class="fas fa-calendar-alt me-2"></i>Gestion des événements
-    </h2>
-
-      <% if has_events %>
-        <div class="d-flex gap-2 flex-wrap">
-          <%= link_to new_admin_event_path, class: "btn-nxr d-inline-flex align-items-center" do %>
-            <i class="fas fa-plus me-2"></i> Créer un événement
-          <% end %>
-
-          <%= link_to admin_events_path, class: "btn-nxr-orange d-inline-flex align-items-center" do %>
-          <i class="fas fa-list-ul me-2"></i> Voir tous les événements
-          <% end %>
-        </div>
-      <% end %>
-    </div>
-
-
-
-  <% if has_events %>
-    <div class="row g-4">
-      <% @events.each do |event| %>
-        <div class="col-sm-6 col-lg-4 mx-auto">
-          <article class="card card-admin shadow-sm rounded-4 h-100 overflow-hidden">
-            <!-- Media -->
-            <div class="ratio ratio-4x3 bg-dark">
-              <% if event.image.attached? %>
-                <%= image_tag event.image, class: "card-img-top object-cover", alt: event.name %>
-              <% else %>
-                <%= image_tag "logo_mcnc_3.png", class: "card-img-top object-contain p-3", alt: event.name %>
-              <% end %>
-            </div>
-
-            <!-- Body -->
-            <div class="card-body d-flex flex-column">
-              <div class="d-flex align-items-start justify-content-between mb-2">
-                <h3 class="h6 fw-bold mb-0"><%= event.name %></h3>
-                <% if event.respond_to?(:status) %>
-                  <span class="badge rounded-pill <%= event.status == "published" ? "bg-success" : "bg-secondary" %>">
-                    <%= event.status.capitalize %>
-                  </span>
-                <% end %>
-              </div>
-
-              <p class="text-tertiary small mb-3">
-                <i class="far fa-clock me-1"></i>
-                <%= l(event.date, format: "%d %B %Y") %>
-              </p>
-
-              <div class="mt-auto d-flex align-items-center justify-content-between">
-                <%= link_to admin_event_path(event),
-                      class: "stretched-link text-decoration-none text-color-primary small me-2" do %>
-                  <i class="fas fa-arrow-right me-1"></i> Voir la fiche
-                <% end %>
-
-                <div class="btn-toolbar gap-2">
-                  <%= link_to edit_admin_event_path(event),
-                        class: "btn btn-icon btn-edit-orange",
-                        title: "Modifier #{event.name}",
-                        aria: { label: "Modifier l'événement #{event.name}" } do %>
-                    <i class="fas fa-edit"></i>
-                  <% end %>
-
-                  <%= link_to admin_event_path(event),
-                        data: { turbo_method: :delete, turbo_confirm: "Supprimer cet événement ?" },
-                        class: "btn btn-icon btn-delete-red",
-                        title: "Supprimer #{event.name}",
-                        aria: { label: "Supprimer l'événement #{event.name}" } do %>
-                    <i class="fas fa-trash"></i>
-                  <% end %>
-                </div>
-              </div>
-            </div>
-          </article>
-        </div>
-      <% end %>
-    </div>
-
-
-  <% else %>
-    <!-- Empty state -->
-    <div class="card-homepage shadow-sm rounded-4 text-center p-5 mx-auto" style="max-width: 640px;">
-      <div class="mb-3">
-        <i class="far fa-calendar-times fa-3x"></i>
-      </div>
-      <h3 class="h5 fw-bold mb-2">Aucun événement pour le moment</h3>
-      <p class="mb-4">Créez votre premier événement pour le club MCNC.</p>
-      <%= link_to new_admin_event_path, class: "btn-nxr d-inline-flex align-items-center" do %>
-        <i class="fas fa-plus me-2"></i>Créer un événement
-      <% end %>
-    </div>
-  <% end %>
-</section>
-
-
-
-
-<hr>
-
+<%# Trainings %>
 <section class="container my-5">
   <% has_trainings = @trainings.present? %>
-
 
   <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-4">
     <h2 class="section-title mb-0">
@@ -133,9 +29,7 @@
       <% end %>
     </div>
 
-
-
-  <% if has_events %>
+  <% if has_trainings %>
     <div class="row g-4">
       <% @trainings.each do |training| %>
         <div class="col-sm-6 col-lg-4 mx-auto">
@@ -145,7 +39,7 @@
               <% if training.image.attached? %>
                 <%= image_tag training.image, class: "card-img-top object-cover", alt: training.name %>
               <% else %>
-                <%= image_tag "logo_mcnc_3.png", class: "card-img-top object-contain p-3", alt: training.name %>
+                <%= image_tag "training_img.png", class: "card-img-top object-contain p-3", alt: training.name %>
               <% end %>
             </div>
 
@@ -209,81 +103,298 @@
     </div>
   <% end %>
 </section>
-<hr>
 
-<h3>Les courses</h3>
+<%# Races %>
 
-<% if @races.empty? %>
-  <p>Vous n'avez pas de course créée pour le moment</p>
-<% else %>
-  <ul>
-    <% @races.each do |race| %>
-      <li><%= race.name %>
+<section class="container my-5">
+  <% has_races = @races.present? %>
 
-          <%= link_to admin_race_path(race), class: "btn btn-primary", aria: { label: "Voir la course #{race.name}" } do %>
-            <i class="fas fa-search"></i>
+  <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-4">
+    <h2 class="section-title mb-0">
+      <i class="fas fa-calendar-alt me-2"></i>Gestion des courses
+    </h2>
+
+      <% if has_races %>
+        <div class="d-flex gap-2 flex-wrap">
+          <%= link_to new_admin_race_path, class: "btn-nxr d-inline-flex align-items-center" do %>
+            <i class="fas fa-plus me-2"></i> Créer une course
           <% end %>
 
-          <%= link_to edit_admin_race_path(race),class: "btn btn-primary", aria: { label: "Modifier la course #{race.name}" } do %>
-            <i class="fas fa-edit"></i>
+          <%= link_to admin_races_path, class: "btn-nxr-orange d-inline-flex align-items-center" do %>
+          <i class="fas fa-list-ul me-2"></i> Voir toutes les courses
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+  <% if has_races %>
+    <div class="row g-4">
+      <% @races.each do |race| %>
+        <div class="col-sm-6 col-lg-4 mx-auto">
+          <article class="card card-admin shadow-sm rounded-4 h-100 overflow-hidden">
+            <!-- Media -->
+            <div class="ratio ratio-4x3 bg-dark">
+              <% if race.image.attached? %>
+                <%= image_tag race.image, class: "card-img-top object-cover", alt: race.name %>
+              <% else %>
+                <%= image_tag "race_flag.png", class: "card-img-top object-contain p-3", alt: race.name %>
+              <% end %>
+            </div>
+
+            <!-- Body -->
+            <div class="card-body d-flex flex-column">
+              <div class="d-flex align-items-start justify-content-between mb-2">
+                <h3 class="h6 fw-bold mb-0"><%= race.name %></h3>
+                <% if race.respond_to?(:status) %>
+                  <span class="badge rounded-pill <%= race.status == "published" ? "bg-success" : "bg-secondary" %>">
+                    <%= race.status.capitalize %>
+                  </span>
+                <% end %>
+              </div>
+
+              <p class="text-tertiary small mb-3">
+                <i class="far fa-clock me-1"></i>
+                <%= l(race.date, format: "%d %B %Y") %>
+              </p>
+
+              <div class="mt-auto d-flex align-items-center justify-content-between">
+                <%= link_to admin_race_path(race),
+                      class: "stretched-link text-decoration-none text-color-primary small me-2" do %>
+                  <i class="fas fa-arrow-right me-1"></i> Voir la fiche
+                <% end %>
+
+                <div class="btn-toolbar gap-2">
+                  <%= link_to edit_admin_race_path(race),
+                        class: "btn btn-icon btn-edit-orange",
+                        title: "Modifier #{race.name}",
+                        aria: { label: "Modifier la course #{race.name}" } do %>
+                    <i class="fas fa-edit"></i>
+                  <% end %>
+
+                  <%= link_to admin_race_path(race),
+                        data: { turbo_method: :delete, turbo_confirm: "Supprimer cette course ?" },
+                        class: "btn btn-icon btn-delete-red",
+                        title: "Supprimer #{race.name}",
+                        aria: { label: "Supprimer la course #{race.name}" } do %>
+                    <i class="fas fa-trash"></i>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      <% end %>
+    </div>
+
+  <% else %>
+    <!-- Empty state -->
+    <div class="card-homepage shadow-sm rounded-4 text-center p-5 mx-auto" style="max-width: 640px;">
+      <div class="mb-3">
+        <i class="far fa-calendar-times fa-3x"></i>
+      </div>
+      <h3 class="h5 fw-bold mb-2">Aucune course pour le moment</h3>
+      <p class="mb-4">Créez votre première course pour le club MCNC.</p>
+      <%= link_to new_admin_event_path, class: "btn-nxr d-inline-flex align-items-center" do %>
+        <i class="fas fa-plus me-2"></i>Créer une course
+      <% end %>
+    </div>
+  <% end %>
+</section>
+
+<%# Events %>
+
+<section class="container my-5">
+  <% has_events = @events.present? %>
+
+
+  <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-4">
+    <h2 class="section-title mb-0">
+      <i class="fas fa-calendar-alt me-2"></i>Gestion des événements
+    </h2>
+
+      <% if has_events %>
+        <div class="d-flex gap-2 flex-wrap">
+          <%= link_to new_admin_event_path, class: "btn-nxr d-inline-flex align-items-center" do %>
+            <i class="fas fa-plus me-2"></i> Créer un événement
           <% end %>
 
-          <%= link_to admin_race_path(race),
-            data: { turbo_method: :delete, turbo_confirm: "Es-tu sûr de vouloir supprimer cette course ?" },
-            class: "btn btn-danger",
-            aria: { label: "Supprimer la course #{race.name}" } do %>
-            <i class="fas fa-trash"></i>
+          <%= link_to admin_events_path, class: "btn-nxr-orange d-inline-flex align-items-center" do %>
+          <i class="fas fa-list-ul me-2"></i> Voir tous les événements
           <% end %>
-        </li>
-    <% end %>
-  </ul>
-<% end %>
+        </div>
+      <% end %>
+    </div>
 
-<%= link_to admin_races_path, class: "btn btn-primary", aria: { label: "Voir toutes les courses" } do %>
-  <i class="fas fa-search-plus"></i>
-<% end %>
+  <% if has_events %>
+    <div class="row g-4">
+      <% @events.each do |event| %>
+        <div class="col-sm-6 col-lg-4 mx-auto">
+          <article class="card card-admin shadow-sm rounded-4 h-100 overflow-hidden">
+            <!-- Media -->
+            <div class="ratio ratio-4x3 bg-dark">
+              <% if event.image.attached? %>
+                <%= image_tag event.image, class: "card-img-top object-cover", alt: event.name %>
+              <% else %>
+                <%= image_tag "logo_mcnc_3.png", class: "card-img-top object-contain p-3", alt: event.name %>
+              <% end %>
+            </div>
 
-<%= link_to new_admin_race_path, class: "btn btn-primary", aria: { label: "Créer une nouvelle course" } do %>
-<i class="fas fa-plus"></i>
-<% end %>
+            <!-- Body -->
+            <div class="card-body d-flex flex-column">
+              <div class="d-flex align-items-start justify-content-between mb-2">
+                <h3 class="h6 fw-bold mb-0"><%= event.name %></h3>
+                <% if event.respond_to?(:status) %>
+                  <span class="badge rounded-pill <%= event.status == "published" ? "bg-success" : "bg-secondary" %>">
+                    <%= event.status.capitalize %>
+                  </span>
+                <% end %>
+              </div>
 
-<hr>
+              <p class="text-tertiary small mb-3">
+                <i class="far fa-clock me-1"></i>
+                <%= l(event.date, format: "%d %B %Y") %>
+              </p>
 
-<h3>Les articles</h3>
+              <div class="mt-auto d-flex align-items-center justify-content-between">
+                <%= link_to admin_event_path(event),
+                      class: "stretched-link text-decoration-none text-color-primary small me-2" do %>
+                  <i class="fas fa-arrow-right me-1"></i> Voir la fiche
+                <% end %>
 
-<% if @articles.empty? %>
-  <p>Vous n'avez pas d'article crée pour le moment</p>
-<% else %>
-  <ul>
-    <% @articles.each do |article| %>
-      <li><%= article.title %>
+                <div class="btn-toolbar gap-2">
+                  <%= link_to edit_admin_event_path(event),
+                        class: "btn btn-icon btn-edit-orange",
+                        title: "Modifier #{event.name}",
+                        aria: { label: "Modifier l'événement #{event.name}" } do %>
+                    <i class="fas fa-edit"></i>
+                  <% end %>
 
-          <%= link_to admin_article_path(article), class: "btn btn-primary", aria: { label: "Voir l'article #{article.title}" } do %>
-            <i class="fas fa-search"></i>
+                  <%= link_to admin_event_path(event),
+                        data: { turbo_method: :delete, turbo_confirm: "Supprimer cet événement ?" },
+                        class: "btn btn-icon btn-delete-red",
+                        title: "Supprimer #{event.name}",
+                        aria: { label: "Supprimer l'événement #{event.name}" } do %>
+                    <i class="fas fa-trash"></i>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      <% end %>
+    </div>
+
+  <% else %>
+    <!-- Empty state -->
+    <div class="card-homepage shadow-sm rounded-4 text-center p-5 mx-auto" style="max-width: 640px;">
+      <div class="mb-3">
+        <i class="far fa-calendar-times fa-3x"></i>
+      </div>
+      <h3 class="h5 fw-bold mb-2">Aucun événement pour le moment</h3>
+      <p class="mb-4">Créez votre premier événement pour le club MCNC.</p>
+      <%= link_to new_admin_event_path, class: "btn-nxr d-inline-flex align-items-center" do %>
+        <i class="fas fa-plus me-2"></i>Créer un événement
+      <% end %>
+    </div>
+  <% end %>
+</section>
+
+<%# Les News %>
+
+<section class="container my-5">
+  <% has_articles = @articles.present? %>
+
+  <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-4">
+    <h2 class="section-title mb-0">
+      <i class="fas fa-calendar-alt me-2"></i>Gestion des articles
+    </h2>
+
+      <% if has_articles %>
+        <div class="d-flex gap-2 flex-wrap">
+          <%= link_to new_admin_race_path, class: "btn-nxr d-inline-flex align-items-center" do %>
+            <i class="fas fa-plus me-2"></i> Créer un article
           <% end %>
 
-          <%= link_to edit_admin_article_path(article),class: "btn btn-primary", aria: { label: "Modifier l'article #{article.title}" } do %>
-            <i class="fas fa-edit"></i>
+          <%= link_to admin_articles_path, class: "btn-nxr-orange d-inline-flex align-items-center" do %>
+          <i class="fas fa-list-ul me-2"></i> Voir tous les articles
           <% end %>
+        </div>
+      <% end %>
+    </div>
 
-          <%= link_to admin_article_path(article),
-            data: { turbo_method: :delete, turbo_confirm: "Es-tu sûr de vouloir supprimer cet article ?" },
-            class: "btn btn-danger",
-            aria: { label: "Supprimer l'article #{article.title}" } do %>
-            <i class="fas fa-trash"></i>
-          <% end %>
-        </li>
-    <% end %>
-  </ul>
-<% end %>
+  <% if has_articles %>
+    <div class="row g-4">
+      <% @articles.each do |article| %>
+        <div class="col-sm-6 col-lg-4 mx-auto">
+          <article class="card card-admin shadow-sm rounded-4 h-100 overflow-hidden">
+            <!-- Media -->
+            <div class="ratio ratio-4x3 bg-dark">
+              <% if article.image.attached? %>
+                <%= image_tag article.image, class: "card-img-top object-cover", alt: article.title %>
+              <% else %>
+                <%= image_tag "logo_mcnc_3.png", class: "card-img-top object-contain p-3", alt: article.title %>
+              <% end %>
+            </div>
 
-<%= link_to admin_articles_path, class: "btn btn-primary", aria: { label: "Voir tous les articles" } do %>
-  <i class="fas fa-search-plus"></i>
-<% end %>
+            <!-- Body -->
+            <div class="card-body d-flex flex-column">
+              <div class="d-flex align-items-start justify-content-between mb-2">
+                <h3 class="h6 fw-bold mb-0"><%= article.title %></h3>
+                <% if article.respond_to?(:status) %>
+                  <span class="badge rounded-pill <%= article.status == "published" ? "bg-success" : "bg-secondary" %>">
+                    <%= article.status.capitalize %>
+                  </span>
+                <% end %>
+              </div>
 
-<%= link_to new_admin_article_path, class: "btn btn-primary", aria: { label: "Créer un nouvel article" } do %>
-<i class="fas fa-plus"></i>
-<% end %>
+              <p class="text-tertiary small mb-3">
+                <i class="far fa-clock me-1"></i>
+                <%= l(article.date, format: "%d %B %Y") %>
+              </p>
+
+              <div class="mt-auto d-flex align-items-center justify-content-between">
+                <%= link_to admin_article_path(article),
+                      class: "stretched-link text-decoration-none text-color-primary small me-2" do %>
+                  <i class="fas fa-arrow-right me-1"></i> Voir l'article
+                <% end %>
+
+                <div class="btn-toolbar gap-2">
+                  <%= link_to edit_admin_article_path(article),
+                        class: "btn btn-icon btn-edit-orange",
+                        title: "Modifier #{article.title}",
+                        aria: { label: "Modifier l'article' #{article.title}" } do %>
+                    <i class="fas fa-edit"></i>
+                  <% end %>
+
+                  <%= link_to admin_article_path(article),
+                        data: { turbo_method: :delete, turbo_confirm: "Supprimer cet article ?" },
+                        class: "btn btn-icon btn-delete-red",
+                        title: "Supprimer #{article.title}",
+                        aria: { label: "Supprimer l'article' #{article.title}" } do %>
+                    <i class="fas fa-trash"></i>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      <% end %>
+    </div>
+
+  <% else %>
+    <!-- Empty state -->
+    <div class="card-homepage shadow-sm rounded-4 text-center p-5 mx-auto" style="max-width: 640px;">
+      <div class="mb-3">
+        <i class="far fa-calendar-times fa-3x"></i>
+      </div>
+      <h3 class="h5 fw-bold mb-2">Aucun article pour le moment</h3>
+      <p class="mb-4">Créez votre premier article pour le club MCNC.</p>
+      <%= link_to new_admin_event_path, class: "btn-nxr d-inline-flex align-items-center" do %>
+        <i class="fas fa-plus me-2"></i>Créer un article
+      <% end %>
+    </div>
+  <% end %>
+</section>
 
 <hr>
 

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -111,42 +111,104 @@
 
 <hr>
 
-<h3>Les entraînements</h3>
+<section class="container my-5">
+  <% has_trainings = @trainings.present? %>
 
-<% if @trainings.empty? %>
-  <p>Vous n'avez pas d'entraînement crée pour le moment</p>
-<% else %>
-  <ul>
-    <% @trainings.each do |training| %>
-      <li><%= training.name %>
 
-          <%= link_to admin_training_path(training), class: "btn btn-primary", aria: { label: "Voir l'entraînement #{training.name}" } do %>
-            <i class="fas fa-search"></i>
+  <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-4">
+    <h2 class="section-title mb-0">
+      <i class="fas fa-calendar-alt me-2"></i>Gestion des entraînements
+    </h2>
+
+      <% if has_trainings %>
+        <div class="d-flex gap-2 flex-wrap">
+          <%= link_to new_admin_training_path, class: "btn-nxr d-inline-flex align-items-center" do %>
+            <i class="fas fa-plus me-2"></i> Créer un entraînement
           <% end %>
 
-          <%= link_to edit_admin_training_path(training),class: "btn btn-primary", aria: { label: "Modifier l'entraînement #{training.name}" } do %>
-            <i class="fas fa-edit"></i>
+          <%= link_to admin_trainings_path, class: "btn-nxr-orange d-inline-flex align-items-center" do %>
+          <i class="fas fa-list-ul me-2"></i> Voir tous les entraînements
           <% end %>
+        </div>
+      <% end %>
+    </div>
 
-          <%= link_to admin_training_path(training),
-            data: { turbo_method: :delete, turbo_confirm: "Es-tu sûr de vouloir supprimer cet entraînement ?" },
-            class: "btn btn-danger",
-            aria: { label: "Supprimer l'entraînement #{training.name}" } do %>
-            <i class="fas fa-trash"></i>
-          <% end %>
-        </li>
-    <% end %>
-  </ul>
-<% end %>
 
-<%= link_to admin_trainings_path, class: "btn btn-primary", aria: { label: "Voir tous les entraînements" } do %>
-  <i class="fas fa-search-plus"></i>
-<% end %>
 
-<%= link_to new_admin_training_path, class: "btn btn-primary", aria: { label: "Créer un nouvel entraînement" } do %>
-<i class="fas fa-plus"></i>
-<% end %>
+  <% if has_events %>
+    <div class="row g-4">
+      <% @trainings.each do |training| %>
+        <div class="col-sm-6 col-lg-4 mx-auto">
+          <article class="card card-admin shadow-sm rounded-4 h-100 overflow-hidden">
+            <!-- Media -->
+            <div class="ratio ratio-4x3 bg-dark">
+              <% if training.image.attached? %>
+                <%= image_tag training.image, class: "card-img-top object-cover", alt: training.name %>
+              <% else %>
+                <%= image_tag "logo_mcnc_3.png", class: "card-img-top object-contain p-3", alt: training.name %>
+              <% end %>
+            </div>
 
+            <!-- Body -->
+            <div class="card-body d-flex flex-column">
+              <div class="d-flex align-items-start justify-content-between mb-2">
+                <h3 class="h6 fw-bold mb-0"><%= training.name %></h3>
+                <% if training.respond_to?(:status) %>
+                  <span class="badge rounded-pill <%= training.status == "published" ? "bg-success" : "bg-secondary" %>">
+                    <%= training.status.capitalize %>
+                  </span>
+                <% end %>
+              </div>
+
+              <p class="text-tertiary small mb-3">
+                <i class="far fa-clock me-1"></i>
+                <%= l(training.date, format: "%d %B %Y") %>
+              </p>
+
+              <div class="mt-auto d-flex align-items-center justify-content-between">
+                <%= link_to admin_training_path(training),
+                      class: "stretched-link text-decoration-none text-color-primary small me-2" do %>
+                  <i class="fas fa-arrow-right me-1"></i> Voir la fiche
+                <% end %>
+
+                <div class="btn-toolbar gap-2">
+                  <%= link_to edit_admin_training_path(training),
+                        class: "btn btn-icon btn-edit-orange",
+                        title: "Modifier #{training.name}",
+                        aria: { label: "Modifier l'événement #{training.name}" } do %>
+                    <i class="fas fa-edit"></i>
+                  <% end %>
+
+                  <%= link_to admin_training_path(training),
+                        data: { turbo_method: :delete, turbo_confirm: "Supprimer cet entraînement ?" },
+                        class: "btn btn-icon btn-delete-red",
+                        title: "Supprimer #{training.name}",
+                        aria: { label: "Supprimer l'entraînement #{training.name}" } do %>
+                    <i class="fas fa-trash"></i>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      <% end %>
+    </div>
+
+
+  <% else %>
+    <!-- Empty state -->
+    <div class="card-homepage shadow-sm rounded-4 text-center p-5 mx-auto" style="max-width: 640px;">
+      <div class="mb-3">
+        <i class="far fa-calendar-times fa-3x"></i>
+      </div>
+      <h3 class="h5 fw-bold mb-2">Aucun entraînement pour le moment</h3>
+      <p class="mb-4">Créez votre premier entraînement pour le club MCNC.</p>
+      <%= link_to new_admin_training_path, class: "btn-nxr d-inline-flex align-items-center" do %>
+        <i class="fas fa-plus me-2"></i>Créer un entraînement
+      <% end %>
+    </div>
+  <% end %>
+</section>
 <hr>
 
 <h3>Les courses</h3>


### PR DESCRIPTION
🎨FRONT
- Amélioration du style du dashboard admin pour la partie Trainings, Races, Events et Articles
- Changement de l'ordre en passant Events après Trainings et Races

⏭️ NEXT
- Terminer totalement le front du dashboard admin
- Mise en place de la suppression de l'image dans le form de création de Race, Training et Event
- Continuer sur le dashboard member

<img width="1274" height="827" alt="Capture d’écran 2025-09-10 à 08 05 26" src="https://github.com/user-attachments/assets/4d1664f8-3d73-44fa-83da-d0eaad681a62" />
<img width="1276" height="845" alt="Capture d’écran 2025-09-10 à 08 05 45" src="https://github.com/user-attachments/assets/17e3283a-3984-4c1c-b646-f78d2a1202cf" />
<img width="1275" height="832" alt="Capture d’écran 2025-09-10 à 08 06 03" src="https://github.com/user-attachments/assets/359e2785-d2f2-4a86-9067-8a9a51c169c7" />
 