### PR TITLE
✨ Members – dashboard & activités

### DIFF
--- a/app/controllers/members/dashboard_controller.rb
+++ b/app/controllers/members/dashboard_controller.rb
@@ -2,9 +2,9 @@ module Members
   class DashboardController < BaseController
     def index
       @registrations = current_user.registrations.includes(:registerable)
-      @races = Race.all
-      @trainings = Training.all
-      @events = Event.all
+      @events = Event.all.order(date: :asc).limit(10)
+      @trainings = Training.all.order(date: :asc).limit(10)
+      @races = Race.all.order(date: :asc).limit(10)
     end
   end
 end

--- a/app/controllers/members/events_controller.rb
+++ b/app/controllers/members/events_controller.rb
@@ -1,7 +1,17 @@
 module Members
   class EventsController < BaseController
+    include Paginable
     def index
-      @events = Event.all
+      @events = Event.order(date: :asc)
+
+      # Recherche
+      @events = @events.search(params[:q]) if params[:q].present?
+
+      # Préchargement ActiveStorage pour éviter les N+1
+      @events = @events.with_attached_image if Event.reflect_on_attachment(:image)
+
+      # Pagination Kaminari via concern
+      @events = apply_pagination(@events)
     end
 
     def show

--- a/app/controllers/members/races_controller.rb
+++ b/app/controllers/members/races_controller.rb
@@ -1,7 +1,17 @@
 module Members
   class RacesController < BaseController
+    include Paginable
     def index
-      @races = Race.all
+      @races = Race.order(date: :asc)
+
+      # Recherche (si param q présent)
+      @races = @races.search(params[:q]) if params[:q].present?
+
+      # Préchargement ActiveStorage pour éviter les N+1
+      @races = @races.with_attached_image if Race.reflect_on_attachment(:image)
+
+      # Pagination Kaminari
+      @races = apply_pagination(@races)
     end
 
     def show

--- a/app/controllers/members/trainings_controller.rb
+++ b/app/controllers/members/trainings_controller.rb
@@ -1,7 +1,17 @@
 module Members
   class TrainingsController < BaseController
+    include Paginable
     def index
-      @trainings = Training.all
+      @trainings = Training.order(date: :asc)
+
+      # Recherche
+      @trainings = @trainings.search(params[:q]) if params[:q].present?
+
+      # Préchargement ActiveStorage pour éviter les N+1
+      @trainings = @trainings.with_attached_image if Training.reflect_on_attachment(:image)
+
+      # Pagination Kaminari via concern
+      @trainings = apply_pagination(@trainings)
     end
 
     def show

--- a/app/views/members/events/index.html.erb
+++ b/app/views/members/events/index.html.erb
@@ -1,0 +1,11 @@
+<%= render "members/shared/registerable_member_index",
+           title: "Les événements",
+           subtitle: "Tous les événements organisés par le club",
+           title_action: "Les événements",
+           icon: "fas fa-list-ul me-2",
+           registerables: @events,
+           search_path: members_events_path,
+           empty_title: "Aucun événement",
+           empty_message: "Oups, pas d'événement pour l'instant, revenez plus tard." %>
+
+<%= render "shared/pagination", paginated: @events %>

--- a/app/views/members/events/show.html.erb
+++ b/app/views/members/events/show.html.erb
@@ -1,10 +1,178 @@
-<div class="banner" style="background-image: linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4)), url('<%= banner_image_url(@event) %>')">
-    <h1><%= @event.name %></h1>
-    <%= registration_link(@event) %>
+<% if @event.respond_to?(:image) && @event.image.attached? %>
+  <!-- Cas 1 : existant avec image -->
+  <section class="banner-dashboard"
+    style="background-image: linear-gradient(rgba(0,0,0,0.45), rgba(0,0,0,0.55)), url('<%= banner_image_url(@event) %>');">
+    <div class="container py-5 text-center">
+      <h1 class="display-5 fw-bold mb-0"><%= @event.name %></h1>
+      <% if @event.respond_to?(:date) && @event.date.present? %>
+          <div class=" w-bold mt-2 text-on-surface">
+            <i class="far fa-calendar-alt me-1"></i>
+            <%= l(@event.date, format: "%d %B %Y") %>
+          </div>
+      <% end %>
+    </div>
+  </section>
+
+<% else %>
+  <!-- Cas 2 : existant sans image -->
+  <section class="profile-user banner-dashboard">
+    <div class="container py-5 text-center">
+      <h1 class="display-5 fw-bold mb-0"><%= @event.name %></h1>
+      <% if @event.respond_to?(:date) && @event.date.present? %>
+          <div class="fw-bold mt-2 text-on-surface">
+            <i class="far fa-calendar-alt me-1"></i>
+            <%= l(@event.date, format: "%d %B %Y") %>
+          </div>
+      <% end %>
+    </div>
+  </section>
+<% end %>
+
+<section class="container my-5">
+  <!-- Barre d’actions -->
+  <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-4">
+    <h2 class="section-title mb-0">
+      <i class="fa-solid fa-list-check"></i> Fiche descriptive
+    </h2>
   </div>
 
-<p><%= @event.description %></p>
+  <div class="row g-4">
+    <!-- Colonne gauche -->
+    <div class="col-lg-4">
+      <article class="card card-admin shadow-sm rounded-4 h-100">
+        <div class="card-body small">
+          <h3 class="h6 fw-bold mb-3"><i class="fa-solid fa-euro-sign me-2"></i>Tarifs</h3>
+
+          <div class="vstack gap-2">
+            <% if @event.respond_to?(:club_member_price) %>
+              <div><strong>Tarif adhérent :</strong>
+                <%= number_to_currency(@event.club_member_price, unit: "€", format: "%n %u") %>
+              </div>
+              <div><strong>Tarif non adhérent :</strong>
+                <%= number_to_currency(@event.non_club_member_price, unit: "€", format: "%n %u") %>
+              </div>
+            <% end %>
+
+            <!-- Infos club -->
+            <% if Club.first.present? %>
+              <% club = Club.first %>
+              <hr>
+              <h3 class="h6 fw-bold mb-3"><i class="fa-solid fa-circle-info me-2"></i>Informations</h3>
+              <p class="mb-1"><strong><%= club.name %></strong></p>
+
+              <% if club.address.present? %>
+                <p class="small mb-1"><i class="fas fa-map-marker-alt me-1"></i> <%= club.address %>, <%= club.post_code %> <%= club.town %></p>
+              <% end %>
+
+              <% if club.phone_number.present? %>
+                <p class="small mb-1"><i class="fas fa-phone me-1"></i> <%= club.phone_number %></p>
+              <% end %>
+
+              <% if club.email.present? %>
+                <p class="small mb-1"><i class="fas fa-envelope me-1"></i> <%= mail_to club.email %></p>
+              <% end %>
+
+              <% if club.address.present? && club.town.present? %>
+                <div class="ratio ratio-4x3 mt-2">
+                  <iframe
+                    src="https://www.google.com/maps?q=<%= CGI.escape("#{club.address}, #{club.post_code} #{club.town}") %>&output=embed"
+                    width="100%" height="100%" style="border:0;" allowfullscreen="" loading="lazy" class="rounded-4">
+                  </iframe>
+                </div>
+              <% end %>
+            <% end %>
+
+            <!-- Statut -->
+            <% if @event.respond_to?(:status) && @event.status.present? %>
+              <% status_badge =
+                   case @event.status.to_s
+                   when "published","open" then "badge-validated"
+                   when "closed","archived" then "badge-rejected"
+                   else "badge-pending"
+                   end %>
+              <div><strong>Statut :</strong>
+                <span class="badge rounded-pill <%= status_badge %>"><%= @event.status.to_s.humanize %></span>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </article>
+    </div>
+
+    <!-- Colonne droite -->
+    <div class="col-lg-8">
+      <!-- Carte d’inscription -->
+      <%= render "members/shared/registerable_registration_card", registerable: @event %>
+
+      <!-- Description -->
+      <article class="card card-admin shadow-sm rounded-4 mb-4">
+        <div class="card-body">
+          <h3 class="h6 fw-bold mb-3"><i class="far fa-file-alt me-2"></i>Description</h3>
+          <div>
+            <%= simple_format(@event.description.presence || "Aucune description fournie.") %>
+          </div>
+        </div>
+      </article>
+
+      <!-- Inscriptions -->
+      <article class="card card-admin shadow-sm rounded-4">
+        <div class="card-body">
+          <% validated_scope =
+               if @event.registrations.respond_to?(:validated)
+                  @event.registrations.validated
+               else
+                 @event.registrations.where(status: :validated)
+               end %>
+
+          <% validated_count = validated_scope.count %>
+          <% registrations = validated_scope.includes(:user).limit(3) %>
+
+          <div class="d-flex align-items-center justify-content-between mb-3">
+            <h3 class="h6 fw-bold mb-0">
+              <i class="fas fa-user-check me-2"></i> Inscriptions validées
+            </h3>
+            <span class="badge rounded-pill"><%= validated_count %></span>
+          </div>
+
+          <% if validated_count.zero? %>
+            <div class="text-center py-4">
+              <i class="far fa-clipboard fa-2x mb-2"></i>
+              <p class="mb-0">Aucune inscription pour le moment.</p>
+            </div>
+          <% else %>
+            <% registrations = @event.registrations.validated.includes(:user).limit(3) %>
+            <div class="row g-3">
+              <% registrations.each do |registration| %>
+                <% user = registration.user %>
+                <div class="col-md-6 col-xl-4">
+                  <article class="card shadow-sm rounded-4 h-100">
+                    <div class="card-body d-flex align-items-center gap-3 position-relative">
+                      <% if user.avatar.attached? %>
+                        <%= image_tag user.avatar, class: "rounded-circle", width: 50, height: 50, alt: "#{user.first_name} #{user.last_name}", style: "object-fit:cover;" %>
+                      <% else %>
+                        <%= image_tag "avatar_default.jpg", class: "rounded-circle", width: 50, height: 50, alt: "#{user.first_name} #{user.last_name}", style: "object-fit:contain;background:rgba(0,0,0,.05);" %>
+                      <% end %>
+
+                      <div class="flex-grow-1">
+                        <div class="fw-bold small"><%= user.first_name %> <%= user.last_name %></div>
+                        <div class="text-muted tiny">
+                          <i class="far fa-clock me-1"></i>
+                          <%= l(registration.created_at, format: :short) %>
+                        </div>
+                      </div>
+                    </div>
+                  </article>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </article>
+    </div>
+  </div>
+</section>
 
 <%= link_to members_dashboard_path, class: "btn btn-primary", aria: { label: "Retour au tableau de bord"} do %>
   <i class="fas fa-home"></i>
 <% end %>
+

--- a/app/views/members/races/index.html.erb
+++ b/app/views/members/races/index.html.erb
@@ -1,11 +1,11 @@
-<div class="banner" style="background-image: linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4)), url(https://cdn.pixabay.com/photo/2017/03/07/12/25/enduro-2123843_1280.jpg);">
-  <h1>Les courses à venir</h1>
-</div>
+<%= render "members/shared/registerable_member_index",
+           title: "Les courses",
+           subtitle: "Toutes les courses organisés par le club",
+           title_action: "Les courses",
+           icon: "fas fa-list-ul me-2",
+           registerables: @races,
+           search_path: members_races_path,
+           empty_title: "Aucune course",
+           empty_message: "Oups, pas de course pour l'instant, revenez plus tard." %>
 
-<% @races.each do |race| %>
-  <ul>
-    <li>
-      <%= race.name %>
-    </li>
-  </ul>
-<% end %>
+<%= render "shared/pagination", paginated: @races %>

--- a/app/views/members/races/show.html.erb
+++ b/app/views/members/races/show.html.erb
@@ -1,10 +1,176 @@
-<div class="banner"
-     style="background-image: linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4)), url('<%= banner_image_url(@race) %>')">
-    <h1><%= @race.name %></h1>
-    <%= registration_link(@race) %>
+<% if @race.respond_to?(:image) && @race.image.attached? %>
+  <!-- Cas 1 : existant avec image -->
+  <section class="banner-dashboard"
+    style="background-image: linear-gradient(rgba(0,0,0,0.45), rgba(0,0,0,0.55)), url('<%= banner_image_url(@race) %>');">
+    <div class="container py-5 text-center">
+      <h1 class="display-5 fw-bold mb-0"><%= @race.name %></h1>
+      <% if @race.respond_to?(:date) && @race.date.present? %>
+          <div class=" w-bold mt-2 text-on-surface">
+            <i class="far fa-calendar-alt me-1"></i>
+            <%= l(@race.date, format: "%d %B %Y") %>
+          </div>
+      <% end %>
+    </div>
+  </section>
+
+<% else %>
+  <!-- Cas 2 : existant sans image -->
+  <section class="profile-user banner-dashboard">
+    <div class="container py-5 text-center">
+      <h1 class="display-5 fw-bold mb-0"><%= @race.name %></h1>
+      <% if @race.respond_to?(:date) && @race.date.present? %>
+          <div class="fw-bold mt-2 text-on-surface">
+            <i class="far fa-calendar-alt me-1"></i>
+            <%= l(@race.date, format: "%d %B %Y") %>
+          </div>
+      <% end %>
+    </div>
+  </section>
+<% end %>
+
+<section class="container my-5">
+  <!-- Barre d’actions -->
+  <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-4">
+    <h2 class="section-title mb-0">
+      <i class="fa-solid fa-list-check"></i> Fiche descriptive
+    </h2>
   </div>
 
-<p><%= @race.description %></p>
+  <div class="row g-4">
+    <!-- Colonne gauche -->
+    <div class="col-lg-4">
+      <article class="card card-admin shadow-sm rounded-4 h-100">
+        <div class="card-body small">
+          <h3 class="h6 fw-bold mb-3"><i class="fa-solid fa-euro-sign me-2"></i>Tarifs</h3>
+
+          <div class="vstack gap-2">
+            <% if @race.respond_to?(:club_member_price) %>
+              <div><strong>Tarif adhérent :</strong>
+                <%= number_to_currency(@race.club_member_price, unit: "€", format: "%n %u") %>
+              </div>
+              <div><strong>Tarif non adhérent :</strong>
+                <%= number_to_currency(@race.non_club_member_price, unit: "€", format: "%n %u") %>
+              </div>
+            <% end %>
+
+            <!-- Infos club -->
+            <% if Club.first.present? %>
+              <% club = Club.first %>
+              <hr>
+              <h3 class="h6 fw-bold mb-3"><i class="fa-solid fa-circle-info me-2"></i>Informations</h3>
+              <p class="mb-1"><strong><%= club.name %></strong></p>
+
+              <% if club.address.present? %>
+                <p class="small mb-1"><i class="fas fa-map-marker-alt me-1"></i> <%= club.address %>, <%= club.post_code %> <%= club.town %></p>
+              <% end %>
+
+              <% if club.phone_number.present? %>
+                <p class="small mb-1"><i class="fas fa-phone me-1"></i> <%= club.phone_number %></p>
+              <% end %>
+
+              <% if club.email.present? %>
+                <p class="small mb-1"><i class="fas fa-envelope me-1"></i> <%= mail_to club.email %></p>
+              <% end %>
+
+              <% if club.address.present? && club.town.present? %>
+                <div class="ratio ratio-4x3 mt-2">
+                  <iframe
+                    src="https://www.google.com/maps?q=<%= CGI.escape("#{club.address}, #{club.post_code} #{club.town}") %>&output=embed"
+                    width="100%" height="100%" style="border:0;" allowfullscreen="" loading="lazy" class="rounded-4">
+                  </iframe>
+                </div>
+              <% end %>
+            <% end %>
+
+            <!-- Statut -->
+            <% if @race.respond_to?(:status) && @race.status.present? %>
+              <% status_badge =
+                   case @race.status.to_s
+                   when "published","open" then "badge-validated"
+                   when "closed","archived" then "badge-rejected"
+                   else "badge-pending"
+                   end %>
+              <div><strong>Statut :</strong>
+                <span class="badge rounded-pill <%= status_badge %>"><%= @race.status.to_s.humanize %></span>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </article>
+    </div>
+
+    <!-- Colonne droite -->
+    <div class="col-lg-8">
+      <!-- Carte d’inscription -->
+      <%= render "members/shared/registerable_registration_card", registerable: @race%>
+
+      <!-- Description -->
+      <article class="card card-admin shadow-sm rounded-4 mb-4">
+        <div class="card-body">
+          <h3 class="h6 fw-bold mb-3"><i class="far fa-file-alt me-2"></i>Description</h3>
+          <div>
+            <%= simple_format(@race.description.presence || "Aucune description fournie.") %>
+          </div>
+        </div>
+      </article>
+
+      <!-- Inscriptions -->
+      <article class="card card-admin shadow-sm rounded-4">
+        <div class="card-body">
+          <% validated_scope =
+               if @race.registrations.respond_to?(:validated)
+                  @race.registrations.validated
+               else
+                 @race.registrations.where(status: :validated)
+               end %>
+
+          <% validated_count = validated_scope.count %>
+          <% registrations = validated_scope.includes(:user).limit(3) %>
+
+          <div class="d-flex align-items-center justify-content-between mb-3">
+            <h3 class="h6 fw-bold mb-0">
+              <i class="fas fa-user-check me-2"></i> Inscriptions validées
+            </h3>
+            <span class="badge rounded-pill"><%= validated_count %></span>
+          </div>
+
+          <% if validated_count.zero? %>
+            <div class="text-center py-4">
+              <i class="far fa-clipboard fa-2x mb-2"></i>
+              <p class="mb-0">Aucune inscription pour le moment.</p>
+            </div>
+          <% else %>
+            <% registrations = @race.registrations.validated.includes(:user).limit(3) %>
+            <div class="row g-3">
+              <% registrations.each do |registration| %>
+                <% user = registration.user %>
+                <div class="col-md-6 col-xl-4">
+                  <article class="card shadow-sm rounded-4 h-100">
+                    <div class="card-body d-flex align-items-center gap-3 position-relative">
+                      <% if user.avatar.attached? %>
+                        <%= image_tag user.avatar, class: "rounded-circle", width: 50, height: 50, alt: "#{user.first_name} #{user.last_name}", style: "object-fit:cover;" %>
+                      <% else %>
+                        <%= image_tag "avatar_default.jpg", class: "rounded-circle", width: 50, height: 50, alt: "#{user.first_name} #{user.last_name}", style: "object-fit:contain;background:rgba(0,0,0,.05);" %>
+                      <% end %>
+
+                      <div class="flex-grow-1">
+                        <div class="fw-bold small"><%= user.first_name %> <%= user.last_name %></div>
+                        <div class="text-muted tiny">
+                          <i class="far fa-clock me-1"></i>
+                          <%= l(registration.created_at, format: :short) %>
+                        </div>
+                      </div>
+                    </div>
+                  </article>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </article>
+    </div>
+  </div>
+</section>
 
 <%= link_to members_dashboard_path, class: "btn btn-primary", aria: { label: "Retour au tableau de bord"} do %>
   <i class="fas fa-home"></i>

--- a/app/views/members/shared/_registerable_member_index.html.erb
+++ b/app/views/members/shared/_registerable_member_index.html.erb
@@ -1,0 +1,90 @@
+<section class="admin-dashboard banner-dashboard">
+  <div class="container py-5">
+    <h1 class="display-5 fw-bold mb-1"><%= title %></h1>
+    <p class="lead mb-0"><%= subtitle %></p>
+  </div>
+</section>
+
+<section class="container my-5">
+  <% has_items = registerables.present? %>
+
+  <!-- Barre d’actions -->
+  <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-4">
+    <h2 class="section-title mb-0">
+      <i class="<%= icon %> me-2"></i><%= title_action %>
+    </h2>
+
+    <!-- Formulaire de recherche -->
+    <div class="d-flex flex-wrap gap-2 flex-grow-1 justify-content-md-end">
+      <%= form_with url: search_path, method: :get, local: true,
+                    class: "search-pill d-flex align-items-center" do |f| %>
+        <%= f.label :q, "Rechercher", class: "visually-hidden" %>
+        <%= f.search_field :q, value: params[:q],
+              class: "form-control form-control-sm border-0 flex-grow-1",
+              placeholder: "Nom, description…" %>
+        <%= button_tag type:"submit", class: "btn-nxr rounded-pill d-flex align-items-center justify-content-center ms-2 px-3" do %>
+          <i class="fa-solid fa-magnifying-glass"></i>
+        <% end %>
+        <% if params[:q].present? %>
+          <%= link_to search_path,
+                class: "btn btn-sm btn-outline-danger rounded-pill d-flex align-items-center justify-content-center ms-2 px-3",
+                title: "Effacer la recherche" do %>
+            <i class="fas fa-times"></i>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
+  <% if has_items %>
+    <div class="row g-4">
+      <% registerables.each do |item| %>
+        <div class="col-sm-6 col-lg-4 d-flex flex-column mx-auto">
+          <article class="card card-admin shadow-sm rounded-4 h-100 overflow-hidden position-relative">
+            <div class="ratio ratio-4x3 bg-dark">
+              <% if item.respond_to?(:image) && item.image.attached? %>
+                <%= image_tag registerable_image_url(item),
+                      class: "card-img-top object-cover",
+                      alt: item.name %>
+              <% else %>
+                <%= image_tag registerable_image_url(item),
+                      class: "card-img-top object-contain p-3",
+                      alt: item.name %>
+              <% end %>
+            </div>
+
+            <div class="card-body d-flex flex-column">
+              <h3 class="h6 fw-bold mb-2"><%= item.name %></h3>
+
+              <% if item.respond_to?(:date) && item.date.present? %>
+                <p class="text-tertiary small mb-2">
+                  <i class="far fa-calendar-alt me-1"></i>
+                  <%= l(item.date, format: "%d %B %Y") %>
+                </p>
+              <% end %>
+
+              <p class="small flex-grow-1">
+                <%= truncate(item.description.to_s, length: 100, separator: ' ') %>
+              </p>
+
+              <div class="mt-auto d-flex justify-content-between align-items-center">
+                <%= link_to [:members, item],
+                      class: "stretched-link btn-nxr small me-2" do %>
+                  <i class="fas fa-search me-1"></i> Voir la fiche
+                <% end %>
+              </div>
+            </div>
+          </article>
+        </div>
+      <% end %>
+    </div>
+
+    <%= render "shared/pagination", pagy_object: pagy if defined?(pagy) %>
+  <% else %>
+    <div class="card-homepage shadow-sm rounded-4 text-center p-5 mx-auto" style="max-width: 640px;">
+      <div class="mb-3"><i class="fas fa-inbox fa-3x"></i></div>
+      <h3 class="h5 fw-bold mb-2"><%= empty_title %></h3>
+      <p class="mb-0"><%= empty_message %></p>
+    </div>
+  <% end %>
+</section>

--- a/app/views/members/trainings/index.html.erb
+++ b/app/views/members/trainings/index.html.erb
@@ -1,11 +1,11 @@
-<div class="banner" style="background-image: linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4)), url(https://cdn.pixabay.com/photo/2017/03/07/12/25/enduro-2123843_1280.jpg);">
-  <h1>Les entraînement à venir</h1>
-</div>
+<%= render "members/shared/registerable_member_index",
+           title: "Les entraînemets",
+           subtitle: "Tous les entraînements organisés par le club",
+           title_action: "Les entraînements",
+           icon: "fas fa-list-ul me-2",
+           registerables: @trainings,
+           search_path: members_trainings_path,
+           empty_title: "Aucun entraînement",
+           empty_message: "Oups, pas d'entraînement pour l'instant, revenez plus tard." %>
 
-<% @trainings.each do |training| %>
-  <ul>
-    <li>
-      <%= training.name %>
-    </li>
-  </ul>
-<% end %>
+<%= render "shared/pagination", paginated: @trainings %>

--- a/app/views/members/trainings/show.html.erb
+++ b/app/views/members/trainings/show.html.erb
@@ -140,7 +140,7 @@
               <p class="mb-0">Aucune inscription pour le moment.</p>
             </div>
           <% else %>
-            <% registrations = @training.registrations.includes(:user).limit(3) %>
+            <% registrations = @training.registrations.validated.includes(:user).limit(3) %>
             <div class="row g-3">
               <% registrations.each do |registration| %>
                 <% user = registration.user %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -10,7 +10,7 @@
 
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav ms-auto">
-        <% if user_signed_in? %>
+        <% if user_signed_in? && current_user.admin? %>
           <li class="nav-item">
             <%= link_to "Accueil", root_path, class: "nav-link" %>
           </li>
@@ -34,7 +34,7 @@
               <% if current_user.avatar.attached? %>
                 <%= image_tag current_user.avatar, class: "avatar me-2", alt: "Mon avatar" %>
               <% else %>
-                <%= image_tag "https://cdn.pixabay.com/photo/2017/08/29/23/49/abstract-background-2695347_1280.jpg", class: "avatar me-2", alt: "Mon avatar" %>
+                <%= image_tag "avatar_default.jpg", class: "avatar me-2", alt: "Mon avatar" %>
               <% end %>
               <span class="d-lg-none">Menu</span>
             </a>
@@ -44,6 +44,43 @@
               <%= link_to "Se déconnecter", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item text-danger" %>
             </div>
           </li>
+
+          <% elsif user_signed_in? && current_user.member? %>
+          <li class="nav-item">
+            <%= link_to "Accueil", root_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "Photos", public_galleries_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "Actualités", public_articles_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "Événements", members_events_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "Entraînements", members_trainings_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "Courses", members_races_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item dropdown">
+            <a href="#" class="nav-link dropdown-toggle d-flex align-items-center" id="navbarDropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <% if current_user.avatar.attached? %>
+                <%= image_tag current_user.avatar, class: "avatar me-2", alt: "Mon avatar" %>
+              <% else %>
+                <%= image_tag "avatar_default.jpg", class: "avatar me-2", alt: "Mon avatar" %>
+              <% end %>
+              <span class="d-lg-none">Menu</span>
+            </a>
+            <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
+              <%= link_to "Profil", edit_user_registration_path, class: "dropdown-item" %>
+              <%= link_to "Tableau de bord", current_user.admin? ? admin_dashboard_path : members_dashboard_path, class: "dropdown-item" %>
+              <%= link_to "Se déconnecter", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item text-danger" %>
+            </div>
+          </li>
+
+
         <% else %>
           <li class="nav-item">
             <%= link_to "Accueil", root_path, class: "nav-link" %>


### PR DESCRIPTION
🎨FRONT
- Tri + limite des events, races, trainings par date.
- Ajout pagination + recherche pour members/events, races, trainings.
- Nouvelles vues members/events (index + show) avec détails et carte d’inscription.
- Partiale _registerable_member_index pour listings unifiés.
- 
<img width="1265" height="847" alt="Capture d’écran 2025-09-22 à 22 30 03" src="https://github.com/user-attachments/assets/47ffb457-ab97-47dd-9dc7-ff30392d9c3b" />
<img width="1261" height="850" alt="Capture d’écran 2025-09-22 à 22 30 38" src="https://github.com/user-attachments/assets/39fa1728-1fa3-4fe3-a893-fb05f448e890" />
<img width="1263" height="849" alt="Capture d’écran 2025-09-22 à 22 30 55" src="https://github.com/user-attachments/assets/b238df79-f7d2-415b-b1c2-1b4437143112" />
<img width="1264" height="825" alt="Capture d’écran 2025-09-22 à 22 31 16" src="https://github.com/user-attachments/assets/b5477d3b-b6bc-44bd-8e08-308de8ea7b97" />
Navbar adaptée selon rôle (admin / member), avatar par défaut corrigé.