### PR TITLE
✨ Terms acceptance – Training/Event

### DIFF
--- a/app/controllers/members/registrations_controller.rb
+++ b/app/controllers/members/registrations_controller.rb
@@ -113,7 +113,7 @@ module Members
           base + %i[cylinder_capacity stroke_type bike_brand race_number terms_accepted]
         )
       when "Training", "Event"
-        params.require(:registration).permit(base)
+        params.require(:registration).permit(base + %i[terms_accepted])
       end
     end
   end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Registration, type: :model do
 
   context "Quand l'utilisateur est inscrit à un événement" do
     it "Le test est valide avec un user lié à un événement" do
-      registration = Registration.new(user: user, registerable: event)
+      registration = Registration.new(user: user, registerable: event, terms_accepted: '1')
       expect(registration).to be_valid
     end
   end

--- a/spec/requests/admin/registrations_spec.rb
+++ b/spec/requests/admin/registrations_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "Admin::Registrations", type: :request do
     context "Quand un admin est connecté et affiche les détails des inscriptions à un événement de type event" do
       it "retourne un status 200, affiche les informations des users inscrit" do
         # Crée une inscription qui sera visible pour l'admin
-        registration = Registration.create!(user: user, registerable: event)
+        registration = Registration.create!(user: user, registerable: event, terms_accepted: '1')
         get admin_event_registration_path(event, registration)
         expect(response).to have_http_status(:ok)
         expect(response.body).to include(user.last_name)
@@ -140,7 +140,8 @@ RSpec.describe "Admin::Registrations", type: :request do
           registerable: race,
           bike_brand: "KTM",
           cylinder_capacity: 50,
-          race_number: "153"
+          race_number: "153",
+          terms_accepted: '1'
         )
         get admin_race_registration_path(race, registration)
         expect(response).to have_http_status(:ok)
@@ -154,7 +155,7 @@ RSpec.describe "Admin::Registrations", type: :request do
     context "Quand un admin est connecté et affiche les détails des inscriptions à un événement de type training" do
       it "retourne un status 200, affiche les informations des users inscrit" do
         # Crée une inscription qui sera visible pour l'admin
-        registration = Registration.create!(user: user, registerable: training)
+        registration = Registration.create!(user: user, registerable: training, terms_accepted: '1')
         get admin_training_registration_path(training, registration)
         expect(response).to have_http_status(:ok)
         expect(response.body).to include(user.last_name)
@@ -167,7 +168,7 @@ RSpec.describe "Admin::Registrations", type: :request do
     context "Quand l'admin delete une inscription lié à événement de type event" do
       it "supprime l'inscription, redirige l'user (302), et valide le test" do
         # Crée une inscription qui sera supprimée pour le test
-        registration = Registration.create!(user: user, registerable: event)
+        registration = Registration.create!(user: user, registerable: event, terms_accepted: '1')
         # expect {...} permet de tester un changement d'état, test les créations et suppressions
         expect {
           delete admin_event_registration_path(event, registration)
@@ -186,7 +187,8 @@ RSpec.describe "Admin::Registrations", type: :request do
           registerable: race,
           bike_brand: "KTM",
           cylinder_capacity: 50,
-          race_number: "153"
+          race_number: "153",
+          terms_accepted: '1'
         )
         # expect {...} permet de tester un changement d'état, test les créations et suppressions
         expect {
@@ -201,7 +203,7 @@ RSpec.describe "Admin::Registrations", type: :request do
     context "Quand l'admin delete une inscription lié à événement de type training" do
       it "supprime l'inscription, redirige l'user (302), et valide le test" do
         # Crée une inscription qui sera supprimée pour le test
-        registration = Registration.create!(user: user, registerable: training)
+        registration = Registration.create!(user: user, registerable: training, terms_accepted: '1')
         # expect {...} permet de tester un changement d'état, test les créations et suppressions
         expect {
           delete admin_training_registration_path(training, registration)

--- a/spec/requests/members/races_spec.rb
+++ b/spec/requests/members/races_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe 'Members::Races', type: :request do
       registerable: race,
       bike_brand: "KTM",
       cylinder_capacity: 50,
-      race_number: "153"
+      race_number: "153",
+      terms_accepted: '1'
     )
   end
 

--- a/spec/requests/members/registrations_spec.rb
+++ b/spec/requests/members/registrations_spec.rb
@@ -124,7 +124,11 @@ RSpec.describe "Members::Registrations", type: :request do
         # expect {...} permet de tester un changement d'état, test les créations et suppressions
         expect {
           post members_event_registrations_path(event), params: {
-            registration: { registerable_id: event.id, registerable_type: "Event" }
+            registration: {
+              registerable_id: event.id,
+              registerable_type: "Event",
+              terms_accepted: true
+            }
           }
         }.to change(Registration, :count).by(1) # Ici permet de vérifier que l'inscription à un event est bien créé en DB
         expect(response).to have_http_status(:redirect) # Vérifie que l'user est bien redirigé (302)
@@ -144,7 +148,8 @@ RSpec.describe "Members::Registrations", type: :request do
               registerable_type: "Race",
               bike_brand: "KTM",
               cylinder_capacity: 50,
-              race_number: "153"
+              race_number: "153",
+              terms_accepted: '1'
             }
           }
         }.to change(Registration, :count).by(1) # Ici permet de vérifier que l'inscription à une race est bien créé en DB
@@ -161,7 +166,11 @@ RSpec.describe "Members::Registrations", type: :request do
         # expect {...} permet de tester un changement d'état, test les créations et suppressions
         expect {
           post members_training_registrations_path(training), params: {
-            registration: { registerable_id: training.id, registerable_type: "Training" }
+            registration: {
+              registerable_id: training.id,
+              registerable_type: "Training",
+              terms_accepted: true
+            }
           }
         }.to change(Registration, :count).by(1) # Ici permet de vérifier que l'inscription à un training est bien créé en DB
         expect(response).to have_http_status(:redirect) # Vérifie que l'user est bien redirigé (302)
@@ -174,7 +183,7 @@ RSpec.describe "Members::Registrations", type: :request do
     context "Quand le membre supprime son inscription lié à événement de type event" do
       it "supprime l'inscription, redirige l'user (302), et valide le test" do
         # Crée une inscription qui sera supprimée pour le test
-        registration = Registration.create!(user: member, registerable: event)
+        registration = Registration.create!(user: member, registerable: event, terms_accepted: '1')
         # expect {...} permet de tester un changement d'état, test les créations et suppressions
         expect {
           delete members_event_registration_path(event, registration)
@@ -193,7 +202,8 @@ RSpec.describe "Members::Registrations", type: :request do
           registerable: race,
           bike_brand: "KTM",
           cylinder_capacity: 50,
-          race_number: "153"
+          race_number: "153",
+          terms_accepted: '1'
         )
         # expect {...} permet de tester un changement d'état, test les créations et suppressions
         expect {
@@ -208,7 +218,7 @@ RSpec.describe "Members::Registrations", type: :request do
     context "Quand le membre supprime son inscription lié à événement de type training" do
       it "supprime l'inscription, redirige l'user (302), et valide le test" do
         # Crée une inscription qui sera supprimée pour le test
-        registration = Registration.create!(user: member, registerable: training)
+        registration = Registration.create!(user: member, registerable: training, terms_accepted: '1')
         # expect {...} permet de tester un changement d'état, test les créations et suppressions
         expect {
           delete members_training_registration_path(training, registration)


### PR DESCRIPTION
🐞BUGGS
- Ajout de terms_accepted dans registration_params pour Training & Event.
- Mise à jour specs (models, requests admin & members) avec terms_accepted.
- Vérification cohérente des inscriptions dans les tests.