### PR TITLE
✨ UI / Refactorisation de la view d'edit au niveau de registration race

### DIFF
--- a/app/views/members/registrations/edit_race.html.erb
+++ b/app/views/members/registrations/edit_race.html.erb
@@ -1,60 +1,110 @@
-<h1>Modification de votre inscription</h1>
+<%# app/views/members/registrations/edit_race.html.erb %>
 
-<% if @registration.registerable.present? %>
-  <p>Événement : <%= @registration.registerable.name %></p>
+<%# ----- Banner (avec/sans image) ----- %>
+<% if @registration.registerable.respond_to?(:image) && @registration.registerable.image.attached? %>
+  <section class="banner-dashboard"
+    style="background-image: linear-gradient(rgba(0,0,0,.45), rgba(0,0,0,.55)), url('<%= banner_image_url(@registration.registerable) %>');">
+    <div class="container py-5 text-center">
+      <h1 class="display-5 fw-bold mb-0"><%= @registration.registerable.name %></h1>
+      <% if @registration.registerable.respond_to?(:date) && @registration.registerable.date.present? %>
+        <div class="fw-bold mt-2 text-on-surface">
+          <i class="far fa-calendar-alt me-1"></i>
+          <%= l(@registration.registerable.date, format: "%d %B %Y") %>
+        </div>
+      <% end %>
+    </div>
+  </section>
+<% else %>
+  <section class="profile-user banner-dashboard">
+    <div class="container py-5 text-center">
+      <h1 class="display-5 fw-bold mb-0"><%= @registration.registerable.name %></h1>
+      <% if @registration.registerable.respond_to?(:date) && @registration.registerable.date.present? %>
+        <div class="fw-bold mt-2 text-on-surface">
+          <i class="far fa-calendar-alt me-1"></i>
+          <%= l(@registration.registerable.date, format: "%d %B %Y") %>
+        </div>
+      <% end %>
+    </div>
+  </section>
 <% end %>
 
-<%= simple_form_for @registration, url: polymorphic_path([:members, @registration.registerable, @registration]) do |f| %>
-  <%= f.hidden_field :registerable_id %>
-  <%= f.hidden_field :registerable_type %>
+<div class="container d-flex justify-content-center align-items-start py-5">
+  <div class="card-signup shadow p-4 p-md-5 rounded-4 w-100">
+    <div class="d-flex justify-content-center mb-4">
+      <h2 class="text-center">
+        <strong>Modifier mon inscription</strong>
+      </h2>
+    </div>
 
-  <fieldset>
-    <legend>Informations personnelles (non modifiables)</legend>
-    <%= f.input :first_name, label: 'Prénom', input_html: { value: @registration.user.first_name, readonly: true } %>
-    <%= f.input :last_name, label: 'Nom', input_html: { value: @registration.user.last_name, readonly: true } %>
-    <%= f.input :birth_date, label: 'Date de naissance', input_html: { value: @registration.user.birth_date, readonly: true } %>
-    <%= f.input :phone_number, label: 'Téléphone', input_html: { value: @registration.user.phone_number, readonly: true } %>
-    <%= f.input :address, label: 'Adresse', input_html: { value: @registration.user.address, readonly: true } %>
-    <%= f.input :post_code, label: 'Code Postal', input_html: { value: @registration.user.post_code, readonly: true } %>
-    <%= f.input :town, label: 'Ville', input_html: { value: @registration.user.town, readonly: true } %>
-  </fieldset>
+    <%= simple_form_for @registration,
+          url: polymorphic_path([:members, @registration.registerable, @registration]) do |f| %>
+      <%= f.error_notification message: "Veuillez corriger les erreurs ci-dessous." %>
 
-  <fieldset>
-    <legend>Informations sur la course (non modifiables)</legend>
-    <%= f.input :license_code, label: 'Code licence', input_html: { value: @registration.user.license_code, readonly: true } %>
-    <%= f.input :license_number, label: 'Numéro de licence', input_html: { value: @registration.user.license_number, readonly: true } %>
-    <%= f.input :club_name, label: 'Nom du club', input_html: { value: @registration.user.club_name, readonly: true } %>
-    <%= f.input :race_number, label: 'Numéro de course', placeholder: "Veuillez renseigner un numéro de course", required: true %>
-  </fieldset>
+      <%# Identité — lecture seule %>
+      <fieldset class="form-section mb-4">
+        <legend class="section-title">Identité</legend>
+        <div class="row g-3">
+          <div class="col-md-6"><%= f.input :first_name,  label: "Prénom",            input_html: { value: @registration.user.first_name,  readonly: true } %></div>
+          <div class="col-md-6"><%= f.input :last_name,   label: "Nom",               input_html: { value: @registration.user.last_name,   readonly: true } %></div>
+          <div class="col-md-6"><%= f.input :birth_date,  label: "Date de naissance", input_html: { value: @registration.user.birth_date,  readonly: true } %></div>
+          <div class="col-md-6"><%= f.input :phone_number,label: "Téléphone",         input_html: { value: @registration.user.phone_number,readonly: true } %></div>
+          <div class="col-12"><%= f.input :address,       label: "Adresse",           input_html: { value: @registration.user.address,     readonly: true } %></div>
+          <div class="col-md-4"><%= f.input :post_code,   label: "Code postal",       input_html: { value: @registration.user.post_code,   readonly: true } %></div>
+          <div class="col-md-8"><%= f.input :town,        label: "Ville",             input_html: { value: @registration.user.town,        readonly: true } %></div>
+        </div>
+        <p class="small mt-2 mb-0">
+          Vos informations d’identité sont préremplies à partir des données enregistrées dans votre profil.
+        </p>
+        <p class="small mt-2 mb-0">
+          Besoin de modifier ces informations ?
+          <%= link_to "mettez à jour votre profil", edit_user_registration_path, class: "badge-success-full-sm text-decoration-none" %>
+        </p>
+      </fieldset>
 
-  <fieldset>
-    <legend>Informations sur le véhicule (modifiables)</legend>
-    <%= f.input :bike_brand,
-    as: :select,
-    collection: Registration::VALID_BRANDS,
-    label: 'Marque de moto',
-    prompt: "Sélectionner une marque",
-    required: true %>
+      <%# Informations course — lecture seule (sauf N° de course selon ton choix) %>
+      <fieldset class="form-section mb-4">
+        <legend class="section-title">Informations course</legend>
+        <div class="row g-3">
+          <div class="col-md-4"><%= f.input :license_code,   label: "Code licence", input_html: { value: @registration.user.license_code,   readonly: true } %></div>
+          <div class="col-md-4"><%= f.input :license_number, label: "N° licence",   input_html: { value: @registration.user.license_number, readonly: true } %></div>
+          <div class="col-md-4"><%= f.input :club_name,      label: "Club",         input_html: { value: @registration.user.club_name,      readonly: true } %></div>
+          <div class="col-md-6">
+            <%= f.input :race_number, label: "Numéro de course", placeholder: "Ex. 27", required: true %>
+          </div>
+        </div>
+      </fieldset>
 
-   <%= f.input :cylinder_capacity,
-            as: :select,
-            collection: Registration::BIKE_CYLINDER_CAPACITY,
-            label: 'Cylindrée (cc)',
-            prompt: "Sélectionner la cylindrée",
-            required: true %>
+      <%# Véhicule — modifiable %>
+      <fieldset class="form-section mb-4">
+        <legend class="section-title">Informations véhicule</legend>
+        <div class="row g-3">
+          <div class="col-md-4">
+            <%= f.input :bike_brand, as: :select, required: true,
+                  collection: Registration::VALID_BRANDS,
+                  label: "Marque de moto", prompt: "Sélectionner une marque" %>
+          </div>
+          <div class="col-md-4">
+            <%= f.input :cylinder_capacity, as: :select, required: true,
+                  collection: Registration::BIKE_CYLINDER_CAPACITY,
+                  label: "Cylindrée (cc)", prompt: "Sélectionner la cylindrée" %>
+          </div>
+          <div class="col-md-4">
+            <%= f.input :stroke_type, as: :select,
+                  collection: [['2 temps', 'two_stroke'], ['4 temps', 'four_stroke']],
+                  label: "Type de moteur", prompt: "Sélectionner le type" %>
+          </div>
+        </div>
+      </fieldset>
 
-    <%= f.input :stroke_type,
-            label: "Type de moteur",
-            collection: [['2 temps', 'two_stroke'], ['4 temps', 'four_stroke']],
-            prompt: "Sélectionner le type" %>
-  </fieldset>
+      <%= f.hidden_field :registerable_id %>
+      <%= f.hidden_field :registerable_type %>
 
-  <div class="mt-3">
-    <%= f.button :submit, "Modifier l'inscription", class: "btn btn-primary" %>
+      <div class="d-flex gap-2">
+        <%= f.button :submit, "Enregistrer", class: "btn-nxr" %>
+        <%= link_to "Annuler",
+              polymorphic_path([:members, @registration.registerable, @registration]),
+              class: "btn-nxr-orange" %>
+      </div>
+    <% end %>
   </div>
-<% end %>
-
-<p class="mt-3">
-  ⚠️ Si vous souhaitez modifier vos informations personnelles, merci de
-  <%= link_to "cliquer ici", edit_user_registration_path %>.
-</p>
+</div>


### PR DESCRIPTION
🎨FRONT
- Refonte complète de la vue edit_race pour harmoniser le style avec les autres formulaires.
- Ajout d’une bannière (avec/sans image) et mise en forme en sections structurées (Identité, Informations course, Informations véhicule).
- Ajout d’aides contextuelles et liens directs vers la mise à jour du profil.

<img width="1255" height="850" alt="Capture d’écran 2025-09-24 à 14 53 18" src="https://github.com/user-attachments/assets/b33850b1-fed3-4d86-8b8d-e172b1024a2a" />
<img width="1249" height="850" alt="Capture d’écran 2025-09-24 à 14 53 32" src="https://github.com/user-attachments/assets/089c5258-e805-43ab-9be3-3e65401a5aca" />
Boutons modernisés : Enregistrer / Annuler avec styles cohérents.