### PR TITLE
✨ Legal Docs – Public terminé

### DIFF
--- a/app/controllers/public/legal_notice_controller.rb
+++ b/app/controllers/public/legal_notice_controller.rb
@@ -1,0 +1,7 @@
+module Public
+  class LegalNoticeController < BaseController
+    def show
+      @legal_notice = LegalNotice.first
+    end
+  end
+end

--- a/app/controllers/public/legal_notices_controller.rb
+++ b/app/controllers/public/legal_notices_controller.rb
@@ -1,7 +1,0 @@
-module Public
-  class LegalNoticesController < BaseController
-    def show
-      @legal_notice = LegalNotice.new
-    end
-  end
-end

--- a/app/controllers/public/privacy_policies_controller.rb
+++ b/app/controllers/public/privacy_policies_controller.rb
@@ -1,7 +1,0 @@
-module Public
-  class PrivacyPoliciesController < BaseController
-    def show
-      @privacy_policy = PrivacyPolicy.new
-    end
-  end
-end

--- a/app/controllers/public/privacy_policy_controller.rb
+++ b/app/controllers/public/privacy_policy_controller.rb
@@ -1,0 +1,7 @@
+module Public
+  class PrivacyPolicyController < BaseController
+    def show
+      @privacy_policy = PrivacyPolicy.first
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -73,4 +73,10 @@ module ApplicationHelper
       </div>
     HTML
   end
+
+  # Permet d'avoir un chemin de retour sécurisé -> pas de boucle infini avec :back
+  def safe_back_path(default = root_path)
+    referer = request.referer
+    referer == request.original_url ? default : referer
+  end
 end

--- a/app/views/public/legal_notice/show.html.erb
+++ b/app/views/public/legal_notice/show.html.erb
@@ -1,0 +1,42 @@
+<%# ancre pour le bouton "Haut de page" %>
+<section class="container my-5">
+
+  <article class="card card-admin shadow-sm rounded-4 overflow-hidden">
+    <%# Bandeau image si présente %>
+    <% if @legal_notice.respond_to?(:image) && @legal_notice.image.attached? %>
+      <div class="ratio ratio-16x9">
+        <%= image_tag @legal_notice.image, class: "w-100 h-100 object-fit-cover" %>
+      </div>
+    <% end %>
+
+    <div class="card-body p-4">
+      <header class="mb-3 text-center">
+        <h1 class="fw-bold mb-1"><%= @legal_notice.title.presence || "Mentions légales" %></h1>
+      </header>
+
+      <% if @legal_notice.body.present? %>
+        <div class="prose">
+          <%= simple_format(h(@legal_notice.body)) %>
+        </div>
+        <% if @legal_notice.created_at.present? %>
+          <p class="text-tertiary small mb-0">
+            <i class="far fa-clock me-1"></i>
+            Publié le <%= l(@legal_notice.created_at, format: :long) %>
+          </p>
+        <% end %>
+      <% else %>
+        <div>
+          Aucune mention légale enregistrée pour le moment.
+        </div>
+      <% end %>
+
+      <%# Btn de retour -> voir application_helper.rb%>
+      <div class="d-flex justify-content-end mt-4">
+        <%= link_to safe_back_path, class: "btn-nxr d-inline-flex align-items-center" do %>
+          <i class="fas fa-arrow-left me-2"></i> Retour
+        <% end %>
+      </div>
+
+    </div>
+  </article>
+</section>

--- a/app/views/public/privacy_policy/show.html.erb
+++ b/app/views/public/privacy_policy/show.html.erb
@@ -1,16 +1,7 @@
-<%# app/views/admin/privacy_policies/show.html.erb %>
+<%# app/views/admin/legal_notices/show.html.erb %>
 
 <section class="container my-5">
   <div class="d-flex justify-content-between align-items-center mb-4">
-    <h2 class="mb-0 text-start fs-2 fw-bold text-uppercase">
-      <i class="fa-solid fa-shield-halved me-2"></i> Politique de confidentialité
-    </h2>
-
-    <div class="d-flex gap-2">
-      <%= link_to edit_admin_privacy_policy_path, class: "btn-nxr d-inline-flex align-items-center" do %>
-        <i class="fas fa-edit me-2"></i> Modifier
-      <% end %>
-    </div>
   </div>
 
   <article class="card card-admin shadow-sm rounded-4 overflow-hidden">
@@ -22,16 +13,16 @@
     <% end %>
 
     <div class="card-body p-4">
-      <header class="mb-3">
-        <h3 class="h5 fw-bold mb-1"><%= @privacy_policy.title.presence || "Politique de confidentialité" %></h3>
+      <header class="mb-3 text-center">
+        <h1 class="fw-bold mb-1"><%= @privacy_policy.title.presence || "Mentions légales" %></h1>
       </header>
 
-      <% if @privacy_policy.body.present? %> <%# remplace par .body si besoin %>
+      <% if @privacy_policy.body.present? %>
         <div class="prose">
           <%= simple_format(h(@privacy_policy.body)) %>
         </div>
         <% if @privacy_policy.created_at.present? %>
-          <p class="text-tertiary small mb-0 mt-3">
+          <p class="text-tertiary small mb-0">
             <i class="far fa-clock me-1"></i>
             Publié le <%= l(@privacy_policy.created_at, format: :long) %>
           </p>
@@ -39,9 +30,15 @@
       <% else %>
         <div>
           Aucune politique de confidentialité enregistrée pour le moment.
-          <%= link_to "Ajouter un contenu", edit_admin_privacy_policy_path, class: "ms-1" %>
         </div>
       <% end %>
+
+      <%# Btn de retour -> voir application_helper.rb%>
+      <div class="d-flex justify-content-end mt-4">
+        <%= link_to safe_back_path, class: "btn-nxr d-inline-flex align-items-center" do %>
+          <i class="fas fa-arrow-left me-2"></i> Retour
+        <% end %>
+      </div>
     </div>
   </article>
 </section>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,8 +3,8 @@
     <p class="mb-1">&copy; <%= Time.current.year %> MCNC - Motocross Club de Navès Castres</p>
     <p class="mb-2">Tous droits réservés</p>
     <div>
-      <%= link_to "Mentions légales", "#", class: "mx-2" %>|
-      <%= link_to "Politique de confidentialité", "#", class: "mx-2" %>|
+      <%= link_to "Mentions légales", mentions_legales_path, class: "mx-2" %>|
+      <%= link_to "Politique de confidentialité", politique_confidentialite_path, class: "mx-2" %>|
       <%= link_to "Contact", "#", class: "mx-2" %>
     <div class="mt-2 social-icons">
       <a href="https://www.facebook.com/profile.php?id=100082078692790" target="_blank" class="mx-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,8 +64,8 @@ Rails.application.routes.draw do
     get "dashboard", to: "dashboard#index"
   end
 
-  get "/mentions-legales", to: "legal_notice#show", as: :mentions_legales
-  get "/politique-de-confidentialite", to: "privacy_policy#show", as: :politique_confidentialite
+  get "/mentions-legales", to: "public/legal_notice#show", as: :mentions_legales
+  get "/politique-de-confidentialite", to: "public/privacy_policy#show", as: :politique_confidentialite
 
   # path: ''  -> supprime le préfixe du namespace dans l’URL
   namespace :public, path: '' do


### PR DESCRIPTION
🎨 FRONT 
- Ajout des contrôleurs publics Public::LegalNoticeController & Public::PrivacyPolicyController (show).
- Création des vues publiques legal_notice/show et privacy_policy/show avec design cohérent (image, titre, contenu, date, bouton retour).
- Ajout du helper safe_back_path pour un retour sécurisé.
- Correction footer : liens dynamiques vers mentions_legales_path & politique_confidentialite_path.
- Mise à jour des routes : passage des endpoints publics sous namespace public.